### PR TITLE
Fixed content extraction for apnews.com

### DIFF
--- a/src/main/java/de/jetwick/snacktory/utils/Configuration.java
+++ b/src/main/java/de/jetwick/snacktory/utils/Configuration.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
+import java.util.Set;
 
 /**
  * Class enables to load the snacktory configuration from external resources
@@ -29,6 +30,7 @@ final public class Configuration {
     }
 
     private String defaultTimezone;
+    private Set<String> domainsNeedSNIEnabled;
 
     private Configuration() {
     }
@@ -43,5 +45,13 @@ final public class Configuration {
 
     public void setDefaultTimezone(String defaultTimezone) {
         this.defaultTimezone = defaultTimezone;
+    }
+
+    public Set<String> getDomainsNeedSNIEnabled() {
+        return domainsNeedSNIEnabled;
+    }
+
+    public void setDomainsNeedSNIEnabled(Set<String> domainsNeedSNIEnabled) {
+        this.domainsNeedSNIEnabled = domainsNeedSNIEnabled;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,1 +1,3 @@
 defaultTimezone: UTC
+domainsNeedSNIEnabled:
+  - apnews.com

--- a/src/test/resources/de/jetwick/snacktory/apnews.html
+++ b/src/test/resources/de/jetwick/snacktory/apnews.html
@@ -1,0 +1,370 @@
+
+<!DOCTYPE html>
+<html amp lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="icon" type="image/png" href="../../dist/assets/icons/favicon.ico">
+    <title>Deputies fatally shoot man who reportedly shot at neighbor</title>
+    <meta name="keywords" content="Knoxville,U.S. News,Police,Shootings"/>
+    <meta name="description" content="
+              KNOXVILLE, Tenn. (AP) — Knox County Sheriff&#39;s Office deputies shot and killed a man after he reportedly fired shots at a neighbor and into the sky.
+              The Knoxville New"/>
+    <link rel="canonical" href="https://www.apnews.com/0290dd1b2048498783f3d7d0ea28a10d"/>
+
+    <!-- OG Tags -->
+    <meta property="og:url" content="https://www.apnews.com/amp/0290dd1b2048498783f3d7d0ea28a10d"/>
+    <meta property="og:image" content="https://www.apnews.com/dist/assets/images/Twitterlogo.png"/>
+    <meta property="og:image:width" content="800"/>
+    <meta property="og:image:height" content="600"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="Deputies fatally shoot man who reportedly shot at neighbor"/>
+    <meta property="og:site_name" content="AP News"/>
+    <meta property="fb:app_id" content="870613919693099"/>
+    <meta property="og:locale" content="en_US"/>
+    <meta property="og:description" content="
+              KNOXVILLE, Tenn. (AP) — Knox County Sheriff&#39;s Office deputies shot and killed a man after he reportedly fired shots at a neighbor and into the sky.
+              The Knoxville New"/>
+    <meta property="article:publisher" content="https://www.facebook.com/APNews"/>
+
+    <!-- Twitter Card tags -->
+    <meta property="twitter:card" content="summary_large_image"/>
+    <meta property="twitter:site" content="@ap"/>
+    <meta property="twitter:title" content="Deputies fatally shoot man who reportedly shot at neighbor"/>
+    <meta property="twitter:description" content="
+              KNOXVILLE, Tenn. (AP) — Knox County Sheriff&#39;s Office deputies shot and killed a man after he reportedly fired shots at a neighbor and into the sky.
+              The Knoxville New"/>
+    <meta property="twitter:image" content="https://www.apnews.com/dist/assets/images/Twitterlogo.png"/>
+    <meta property="twitter:url" content=" https://www.apnews.com/0290dd1b2048498783f3d7d0ea28a10d"/>
+    <meta name="twitter:image:alt" content="https://www.apnews.com/dist/assets/images/Twitterlogo.png"/>
+
+    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+    <style amp-custom>
+
+
+        @font-face {
+            font-family: GoodWeb-Bold;
+            font-style: normal;
+            font-weight: 400;
+            src: url('../../dist/assets/fonts/GoodWeb-CondBold.woff')format("woff")
+        }
+
+        @font-face {
+            font-family: FreightText;
+            src: url("../../dist/assets/fonts/FreigTexProMed.otf");
+        }
+
+        @font-face {
+            font-family: GoodWeb-Book;
+            src: url("../../dist/assets/fonts/GoodWeb-Book.eot");
+        }
+
+        .logo {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+        }
+
+        .header {
+            width: 100%;
+            height: 75px;
+            background-color: #157ea0;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 600px;
+            min-height: 600px;
+            margin: 0 auto;
+            margin-bottom: 50px;
+        }
+
+        .container article {
+            margin: 0 auto;
+            width:90%;
+        }
+
+        .container .articleBody{
+            line-height: 1.6;
+        }
+
+        .container img {
+            width: 100%;
+            object-fit: contain;
+            object-position: top;
+        }
+
+        .container h1, h4 {
+            font-family: GoodWeb-Bold, "Arial Narrow Bold", "Arial Narrow", Trebuchet, Arial, sans-serif;
+        }
+
+        .topTags {
+            width: 90%;
+            margin: 0 auto;
+            margin-top: 20px;
+            margin-bottom: 20px;
+        }
+
+        ul {
+            padding: 0;
+        }
+
+        li {
+            display: inline;
+        }
+
+        .tagsList a {
+            text-decoration: none;
+            color: #157ea0;
+            font-family: GoodWeb, "Arial Narrow", "Arial Narrow", Trebuchet, Arial, sans-serif;
+        }
+
+        .tagsList:first-child:before {
+            content: "";
+        }
+
+        .tagsList:before {
+            content: " • ";
+            color: gray;
+        }
+
+        body {
+            background-color: #f1f1f1;
+            font-family: FreightText, Georgia, "Times New Roman", Times, serif;
+        }
+
+        amp-img {
+            background-color: gray;
+        }
+        .primaryMediaContainer{
+            position: relative;
+        }
+
+        .primaryMediaContainer .caption{
+            bottom:-17px;
+        }
+
+        .primaryMediaContainer ~.topTags{
+            margin-top:30px;
+        }
+
+        .amp-carousel-button {
+            visibility: visible;
+            opacity: 1;
+            border-radius: 50%;
+            border-style: solid;
+            border-width: 1px;
+            border-color: #3c3c3c;
+            width: 25px;
+            height: 25px;
+        }
+
+
+        .caption {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 1px;
+            background: black;
+            color: #ddd;
+            font-size: smaller;
+            z-index: 11;
+
+        }
+
+        .embeddedCaption .caption{
+            position: relative;
+            background:none;
+            color: black;
+        }
+
+        .closeCaption {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            z-index: 12;
+        }
+        .caption > a {
+            cursor: pointer;
+            display: block;
+            width:100px;
+            margin: 0 auto;
+            font-size:16px;
+            text-align: center;
+        }
+
+        .caption:focus a {
+            display: none;
+        }
+
+        .caption:focus {
+            outline: none;
+        }
+
+        .caption > div {
+            display: none;
+        }
+
+        .caption:focus div {
+            display: block;
+        }
+
+        .caption:focus ~ .amp-carousel-button{
+            opacity: 0;
+        }
+
+        .caption:focus ~ .closeCaption{
+            display: block;
+        }
+        .caption ~ .closeCaption{
+            display:none;
+        }
+        .taboolaContainer{
+            padding:20px;
+        }
+
+        .footer {
+            padding-left:20px;
+            background-color: #d6d6d6;
+            width: 100%;
+            height: 50px;
+        }
+        .footer ul{
+            padding-top:10px;
+        }
+        .footer a{
+            color:black;
+            text-decoration: none;
+        }
+
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://www.apnews.com/0290dd1b2048498783f3d7d0ea28a10d"
+        },
+        "headline": "Deputies fatally shoot man who reportedly shot at neighbor",
+        "image":{
+            "@type": "ImageObject",
+            "url": "https://apnews.com/dist/assets/images/Twitterlogo.png",
+            "height": 360,
+            "width": 700
+        },
+        "datePublished": "2017-05-24 21:50:34",
+        "dateModified": "2017-05-24 21:50:34",
+        "author": {
+            "@type": "Person",
+            "name": "AP Staff"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Associated Press",
+            "logo": {
+              "@type": "ImageObject",
+              "url": "http://apcontextual.appspot.com/Support/AMPLogo.png",
+              "width": 600,
+              "height": 60
+            }
+        },
+        "description": ""
+      }
+    </script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<header id="header" class="header">
+    <div class="logo">
+        <a href="/">
+            <amp-img src="../../dist/assets/images/AssociatedPress_logo.png" alt="AP" height="50" width="43"></amp-img>
+        </a>
+    </div>
+</header>
+
+<div class="container">
+
+
+
+    <ul class="topTags">
+
+        <li class="tagsList">
+            <a href="/tag/Knoxville">Knoxville</a>
+        </li>
+
+        <li class="tagsList">
+            <a href="/tag/Police">Police</a>
+        </li>
+
+        <li class="tagsList">
+            <a href="/tag/Shootings">Shootings</a>
+        </li>
+
+    </ul>
+
+    <article>
+        <h1>Deputies fatally shoot man who reportedly shot at neighbor</h1>
+        <h4></h4>
+        <h4>May. 24, 2017</h4>
+        <div class="articleBody">
+
+            <p>KNOXVILLE, Tenn. (AP) &#8212; Knox County Sheriff's Office deputies shot and killed a man after he reportedly fired shots at a neighbor and into the sky.</p>
+            <p>The Knoxville News Sentinel reports (<a href="http://bit.ly/2rPNu9h">http://bit.ly/2rPNu9h</a> ) that Knoxville Police Department spokesman Darrell DeBusk says deputies responding to multiple reports of a shooting Tuesday evening confronted the man, who was armed with a pistol and long gun. Deputies returned fire after the man fired additional shots. He was taken to a hospital, where he was pronounced dead.</p>
+            <p>No deputies were harmed.</p><div class="ad-placeholder"></div>
+            <p>DeBusk did not provide any further details about the deceased man. He says the Knoxville Police Department is conducting a criminal investigation, and the Sheriff's Office is conducting an administrative investigation per an inter-agency agreement to investigate each other's officer-involved shootings in the interest of transparency.</p>
+            <p>___</p>
+            <p>Information from: Knoxville News Sentinel, <a href="http://www.knoxnews.com">http://www.knoxnews.com</a></p>
+
+        </div>
+    </article>
+</div>
+<div class="taboolaContainer">
+    <amp-embed width=100 height=283
+               type=taboola
+               layout=responsive
+               heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+               data-publisher="associatedpress-apnews"
+               data-mode="thumbnails-a"
+               data-placement="Ads Example"
+               data-article="auto">
+    </amp-embed>
+</div>
+
+<footer class="footer">
+    <ul>
+        <li>
+            <a href="#">About</a>
+        </li>
+        <li>
+            <a href="#">Terms and Conditions</a>
+        </li>
+        <li>
+            <a href="#">Privacy</a>
+        </li>
+    </ul>
+</footer>
+
+<amp-analytics type="googleanalytics" id="analytics1">
+    <script type="application/json">
+        {
+            "vars": {
+                "account": "UA-19104461-33"
+            },
+            "triggers": {
+                "pageview": {
+                    "on": "visible",
+                    "request": "pageview"
+                }
+            }
+        }
+    </script>
+</amp-analytics>
+</body>
+</html>


### PR DESCRIPTION
----
https://www.apnews.com/amp/0290dd1b2048498783f3d7d0ea28a10d

Root Cause:
1. https://www.apnews.com/amp/0290dd1b2048498783f3d7d0ea28a10d:javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake
2. After enabling the SSL logs -Djavax.net.debug=ssl:handshake:verbose came to know that the www.apnews.com expects the Server Name Indication during SSL handshake.
3. The snactory has disabled the SSL Hostname Verification by introducing custom verifier de.jetwick.snacktory.HtmlFetcher.NullHostnameVerifier. As a side effect of this, SNI is not set correctly.

Solution:
1. Disabling the NullHostnameVerifier completely may not work for all the sites SSL verification may fail for many sites.
2. Added a check to specify if site requires SNI to be provided in requests. The domain names can be provided from the config.yaml