### PR TITLE
Nytimes.com - Fixed content extraction

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -201,6 +201,9 @@ public class ArticleTextExtractor {
         aMap.put("inforisktoday", Arrays.asList(
                 "p:has(b):contains(See Also:)"
             ));
+        aMap.put("nytimes.com", Arrays.asList(
+                "[class*=hidden]"
+            ));
 
         NODES_TO_REMOVE_PER_DOMAIN = Collections.unmodifiableMap(aMap);
     }

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -374,6 +374,7 @@ public class ArticleTextExtractorTest {
         assertEquals("Robert Mueller, Former F.B.I. Director, Is Named Special Counsel for Russia Investigation", res.getTitle());
         assertTrue(res.getText(), res.getText().startsWith("WASHINGTON — The Justice Department appointed Robert S. Mueller III, a former F.B.I. director,"));
         assertFalse(res.getText(), res.getText().contains("Please verify you're not a robot by clicking the box. Invalid email address."));
+        assertFalse(res.getText(), res.getText().contains("View all New York Times newsletters. See Sample Manage Email Preferences Not you? Privacy Policy"));
         assertTrue(res.getText(), res.getText().endsWith("He’s the embodiment of integrity.”"));
         assertEquals("Rebecca R. Ruiz and Mark Landler", res.getAuthorName());
         assertEquals("https://www.nytimes.com/by/rebecca-r-ruiz", res.getAuthorDescription());


### PR DESCRIPTION
- Fixed the issue of unwanted content extraction
- Added rule in NODES_TO_REMOVE_PER_DOMAIN