### PR TITLE
Fixed extraction issues

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -243,6 +243,9 @@ public class ArticleTextExtractor {
         aMap.put("sltrib.com", Arrays.asList(
                 "#main-content > div.row"
         ));
+        aMap.put("sfchronicle.com", Arrays.asList(
+                "div[class=article-text]"
+        ));
 
         BEST_ELEMENT_PER_DOMAIN = Collections.unmodifiableMap(aMap);
     }
@@ -290,7 +293,7 @@ public class ArticleTextExtractor {
                 + "login|si(debar|gn|ngle)");
         setPositive("(^(body|content|h?entry|main|page|post|text|blog|story|haupt))"
                 + "|arti(cle|kel)|instapaper_body|storybody|short-story|storycontent|articletext|story-primary|^newsContent$|dcontainer|announcement-details");
-        setHighlyPositive("news-release-detail|storybody|main-content|articlebody|article_body|article-body|html-view-content|entry__body|^main-article$|^article__content$|^articleContent$|^mainEntityOfPage$|art_body_article|^article_text$|main-article-chapter|post-body");
+        setHighlyPositive("news-detail-content|news-release-detail|storybody|main-content|articlebody|article_body|article-body|html-view-content|entry__body|^main-article$|^article__content$|^articleContent$|^mainEntityOfPage$|art_body_article|^article_text$|main-article-chapter|post-body");
         setNegative("nav($|igation)|user|com(ment|bx)|(^com-)|contact|"
                 + "foot|masthead|(me(dia|ta))|outbrain|promo|related|scroll|(sho(utbox|pping))|"
                 + "sidebar|sponsor|tags|tool|widget|player|disclaimer|toc|infobox|vcard|title|truncate|slider|^sectioncolumns$|ad-container");

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -3079,6 +3079,36 @@ public class ArticleTextExtractorTest {
         compareDates("2017-05-12 00:00:00", res.getDate());
     }
 
+    @Test
+    public void testMorningStar() throws Exception {
+        // http://www.morningstar.com/news/associated-press/urn:publicid:ap.org:f8d53c4370434744a864d4afa5fa8d36/hackers-break-into-centralized-password-manager-onelogin.html
+        JResult res = new JResult();
+        res.setUrl("http://www.morningstar.com/news/associated-press/urn:publicid:ap.org:f8d53c4370434744a864d4afa5fa8d36/hackers-break-into-centralized-password-manager-onelogin.html");
+        res = extractor.extractContent(res, c.streamToString(getClass().getResourceAsStream("morningstar.html")));
+        assertEquals("http://www.morningstar.com/news/associated-press/urn:publicid:ap.org:f8d53c4370434744a864d4afa5fa8d36/hackers-break-into-centralized-password-manager-onelogin.html", res.getCanonicalUrl());
+        assertEquals("Hackers break into centralized password manager OneLogin", res.getTitle());
+        assertTrue(res.getText(), res.getText().startsWith("NEW YORK (AP) — Hackers have gained access to OneLogin,"));
+        assertTrue(res.getText(), res.getText().endsWith("although not actual passwords."));
+        assertEquals(StringUtils.EMPTY, res.getAuthorName());
+        assertEquals(StringUtils.EMPTY, res.getAuthorDescription());
+        compareDates("2017-06-02 00:00:00", res.getDate());
+    }
+
+    @Test
+    public void testSfchronicle() throws Exception {
+        // http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php
+        JResult res = new JResult();
+        res.setUrl("http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php");
+        res = extractor.extractContent(res, c.streamToString(getClass().getResourceAsStream("sfchronicle.html")));
+        assertEquals("http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php", res.getCanonicalUrl());
+        assertEquals("Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club - San Francisco Chronicle", res.getTitle());
+        assertTrue(res.getText(), res.getText().startsWith("San Francisco’s Thumbtack, which introduces fix-it folks,"));
+        assertTrue(res.getText(), res.getText().endsWith("Carolyn Said is a San Francisco Chronicle staff writer. E-mail: csaid@sfchronicle.com Twitter: @csaid"));
+        assertEquals("Carolyn Said", res.getAuthorName());
+        assertEquals("Carolyn Said is a San Francisco Chronicle staff writer. E-mail: csaid@sfchronicle.com Twitter: @csaid", res.getAuthorDescription());
+        compareDates("2015-09-30 00:00:00", res.getDate());
+    }
+
     public static void compareDates(String expectedDateString, Date actual) {
         String[] patterns = {
                 "yyyy-MM-dd",

--- a/src/test/resources/de/jetwick/snacktory/morningstar.html
+++ b/src/test/resources/de/jetwick/snacktory/morningstar.html
@@ -1,0 +1,995 @@
+<!doctype html>
+<html class="msind no-js">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="apple-touch-icon-precomposed" href="/content/dam/morningstar/ret/content/apple-touch-icon.png">
+    <title>Hackers break into centralized password manager OneLogin</title>
+    <meta name="keywords"
+          content="Business,Technology,Computer and data security,Computing and information technology,Hacking,Technology issues"/>
+    <meta name="description"
+          content="Hackers break into centralized password manager OneLogin, Read most current stock market news, Get stock, fund, etf analyst reports from an independent source you can trust – Morningstar"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no"/>
+    <!-- Build MetaData -->
+    <meta name="build" content="3.14.0-SNAPSHOT"/>
+    <meta name="buildTimestamp" content="2017-05-24T13:51:39.039-0500
+"/>
+
+    <meta name="site" content="ms.us"/>
+    <meta name="area" content="News"/>
+    <meta name="assetDomain" content="//www.msmediacom.com/"/>
+    <meta name="adDomain" content="//msmedia.morningstar.com/mstar/"/>
+    <meta name="adRefreshInterval" content="0"/>
+    <meta name="memberDomain" content="members.morningstar.com"/>
+
+
+    <meta name="uimHost" content="https://sso.morningstar.com/sso/"/>
+    <meta name="isAuthor" content="false"/>
+    <meta name="isPublish" content="true"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="language" content="en_US"/>
+    <meta name="google-site-verification" content="2d6RajT7NIVDNOSQK7wUW855uF-dxm-vM0kMJRhJAng"/>
+
+
+    <link rel="stylesheet" href="/etc/designs/morningstar/headlib.min.1495651899039.css" type="text/css">
+    <script type="text/javascript" src="/etc/designs/morningstar/headlib.min.1495651899039.js"></script>
+    <script>
+	var appHN = document.getElementsByTagName("head")[0],
+		appMN = document.createElement('meta'),
+		ua = navigator.userAgent;
+
+	if (/(iPad).*AppleWebKit.*Mobile.*Safari/.test(ua) || /(iPhone).*AppleWebKit.*Mobile.*Safari/.test(ua)) {
+		appMN.name = 'apple-itunes-app';
+		if (/(iPad).*AppleWebKit.*Mobile.*Safari/.test(navigator.userAgent)) {
+			appMN.content = 'app-id=676373222, app-argument=http://www.morningstar.com';
+		} else {
+			appMN.content = 'app-id=310716163, app-argument=http://www.morningstar.com';
+		}
+		appHN.appendChild(appMN);
+	}
+
+    </script>
+    <script src="//assets.adobedtm.com/562c4fa30f42e85424963b17e634e8b4638f5016/satelliteLib-a5e753d69c79c7b0e301c08ff437f7f67740cf60.js"></script>
+    <script src="//www.msmediacom.com/safeframe/js/sf_base_host_boot.js?bv=3.14.0-SNAPSHOT"></script>
+    <meta name="template" value="templatenews"/>
+
+
+    <meta name="cat" content=""/>
+    <meta name="section" content="associated-press"/>
+    <meta name="dcterms.date" content="2017-06-02"/>
+    <!--for Facebook Share-->
+    <meta property="og:title" content="Hackers break into centralized password manager OneLogin"/>
+    <meta property="og:description"
+          content="Hackers break into centralized password manager OneLogin, Read most current stock market news, Get stock, fund, etf analyst reports from an independent source you can trust – Morningstar"/>
+
+
+    <link rel="icon" type="image/vnd.microsoft.icon" href="/etc/designs/morningstar/favicon.ico"/>
+    <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/etc/designs/morningstar/favicon.ico"/>
+
+    <meta name="msvalidate.01" content="985532AEAC3A31F64690C69EFA55EF87"/>
+    <meta name="google-site-verification" content="3Ap-qUhJutF7vuC-6nmHXnqzIMjHjOddiGw-YnZ-6PU"/>
+
+
+    <script>
+	(function () {
+		"use strict";
+
+		var v1Host = 'http://www.morningstar.com',
+			v2Host = 'http://beta.morningstar.com',
+			betaOptInPercentage = '0.1',
+			betaCookieName = 'www_beta',
+			betaCookieDomain = '.morningstar.com',
+			overrideParamName = 'optin-override',
+			betaCookiePath = '/',
+			loc = document.location,
+			currentUrlOrigin = loc.origin,
+			currentRelativeUrl = loc.pathname,
+			betaCookieValue = getCookie(betaCookieName),
+			betaCookie = (betaCookieValue ? true : false),
+			betaOptedIn = (betaCookieValue === '1' ? true : false),
+			relativeUrlsForRewrite = ['/stocks.html', '/funds.html', '/etfs.html', '/cefs.html', '/bonds.html', '/invest-in-retirement.html', '/save-for-retirement.html', '/optimize-your-portfolio.html', '/family-finances.html', '/start-investing.html', '/save-for-college.html', '/minimize-taxes.html', '/tools.html', '/members/login.html'],
+			stocksRegEx = /\/stocks\/[^/]*\/[^/]*\/quote.html/g,
+			fundsRegEx = /\/funds\/[^/]*\/[^/]*\/quote.html/g,
+			cefsRegEx = /\/cefs\/[^/]*\/[^/]*\/quote.html/g,
+			etfsRegEx = /\/etfs\/[^/]*\/[^/]*\/quote.html/g,
+			urlIndex = 0,
+			expiryDate = null,
+			enrollUserInBeta = false,
+			betaOverrideParam = false,
+			queryParameters = getQueryParams(loc.search.toLowerCase()),
+			betaSourceIdKey = 'betaSourceId',
+			betaSourceIdValue = 2,
+			queryStringParam = '?optIn=true',
+			betaReferIds = 'A3841,A3842,A3843,A3844,A3845,A3846,A3789,A3790,A3791,A3806,A3813,A3816,A3822,A3825,A3827,A3830,A3836,A3839,A3847,A3848,A3990,A3991,A3992,A3993,A3994',
+			betaReferIdArray = betaReferIds.toLowerCase().split(','),
+			referIdParamName = 'referid',
+            optinBetaReferId = function () {
+                var retVal = false;
+                if (queryParameters !== null && queryParameters.hasOwnProperty(referIdParamName)) {
+                   if (betaReferIdArray.indexOf(queryParameters[referIdParamName]) > -1) {
+                       retVal = true;
+                   }
+                 }
+                 return retVal;
+		    },
+			isOldIE = function () {
+				var ua = navigator.userAgent,
+					retVal = false,
+					items = /MSIE (\d+\.\d+)/i.exec(ua) || [],
+					i = 0;
+
+				if (items.length > 1) {
+					if (parseFloat(items[1]) < 12) {
+						retVal = true;
+					}
+				}
+				if (ua.toLowerCase().indexOf('trident') > -1) {
+					retVal = true;
+				}
+
+				return retVal;
+			};
+
+		if (validString(v1Host) !== '' && validString(v2Host) !== '' && isOldIE() === false && currentUrlOrigin === v1Host && optinBetaReferId() === false) {
+			if (queryParameters !== null && queryParameters.hasOwnProperty(overrideParamName)) {
+				if (queryParameters[overrideParamName][0] === '1') {
+					betaOverrideParam = true;
+				}
+			}
+			if (betaOverrideParam === true) {
+				enrollUserInBeta = true;
+			} else {
+				if (betaCookie === false) {
+					if (betaOptInPercentage === 1) {
+						enrollUserInBeta = true;
+					}
+					if (!enrollUserInBeta && betaOptInPercentage !== 0 && Math.random() <= betaOptInPercentage) {
+						enrollUserInBeta = true;
+					}
+				}else if (betaOptedIn === true){
+					if ((urlIndex = relativeUrlsForRewrite.indexOf(currentRelativeUrl)) !== -1) {
+						loc.replace(v2Host + relativeUrlsForRewrite[urlIndex]);
+					} else {
+						if (stocksRegEx.test(currentRelativeUrl) || fundsRegEx.test(currentRelativeUrl) || etfsRegEx.test(currentRelativeUrl) || cefsRegEx.test(currentRelativeUrl)) {
+							loc.replace(v2Host + currentRelativeUrl);
+						} else if (currentRelativeUrl === '/') {
+							loc.replace(v2Host);
+						}
+					}
+				}
+			}
+			if (enrollUserInBeta === true) {
+				var optionId = 1,
+					betaOptions = 'sourceId=' + betaSourceIdValue + '&optionId=' + optionId,
+					req = new XMLHttpRequest();
+
+				if (typeof window.localStorage === 'object') {
+					localStorage.setItem(betaSourceIdKey, betaSourceIdValue);
+				}
+				req.addEventListener('load', updateResponse);
+				req.open('POST', '/api/v2/user/options', true);
+				req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
+				req.send(betaOptions);
+			} else if (betaCookie === false && betaOptInPercentage !== '0') {
+				expiryDate = new Date();
+				expiryDate.setHours(23, 59, 59);
+				createCookie(betaCookieName, 99, expiryDate, betaCookiePath, betaCookieDomain);
+			}
+		}
+		function updateResponse() {
+			expiryDate = new Date(new Date().getTime() + (182 * 24 * 60 * 60 * 1000));
+			createCookie(betaCookieName, 1, expiryDate, betaCookiePath, betaCookieDomain);
+			betaOptedIn = true;
+			if (betaOptedIn === true) {
+				if ((urlIndex = relativeUrlsForRewrite.indexOf(currentRelativeUrl)) !== -1) {
+					var url = v2Host + relativeUrlsForRewrite[urlIndex];
+					loc.replace(createBetaUrl(url));
+				} else {
+					if (stocksRegEx.test(currentRelativeUrl) || fundsRegEx.test(currentRelativeUrl) || etfsRegEx.test(currentRelativeUrl) || cefsRegEx.test(currentRelativeUrl)) {
+						var url = v2Host + currentRelativeUrl;
+						loc.replace(createBetaUrl(url));
+					} else if (currentRelativeUrl === '/') {
+						loc.replace(createBetaUrl(v2Host));
+					}
+				}
+			}
+		}
+		function createBetaUrl(url) {
+			var newUrl = url;
+			if (getCookie(betaCookieName) === '1') {
+				newUrl += queryStringParam;
+			}
+			return newUrl;
+		}
+		function createCookie(name, value, expires, path, domain) {
+			var cookie = name + '=' + value;
+
+			if (validString(expires) !== '') {
+				cookie += '; expires=' + expires.toUTCString();
+			}
+			if (validString(path) !== '') {
+				cookie += '; path=' + path;
+			}
+			if (validString(domain) !== '') {
+				cookie += '; domain=' + domain;
+			}
+			document.cookie = cookie;
+		}
+		function getCookie(name) {
+			var cookieValue = '',
+				cookie = [],
+				cookies = document.cookie.split(';'),
+				i = 0;
+
+			for (i = 0; i < cookies.length; i = i + 1) {
+				cookie = cookies[i].split('=');
+
+				if (name === (cookie[0] ? cookie[0].trim() : '')) {
+					cookieValue = (cookie[1] ? cookie[1].trim() : '');
+				}
+			}
+
+			return cookieValue;
+		}
+		function getQueryParams(queryString) {
+			var queryParams = {},
+				param = [],
+				params = queryString.substr(1).split('&'),
+				i = 0,
+				key = '',
+				value = '';
+
+			for (i = 0; i < params.length; i = i + 1) {
+				param = params[i].split('=');
+				key = param[0];
+				value = decodeURIComponent(param[1]);
+
+				queryParams[key] = value;
+			}
+
+			return queryParams;
+		}
+		function validString(str) {
+			try {
+				if (typeof str === 'string' && str !== '') {
+					return str;
+				} else {
+					return str.toString();
+				}
+			} catch(e) {
+				return '';
+			}
+		}
+	}());
+
+    </script>
+
+
+</head>
+
+
+<body class="template-templatenews">
+<script>
+	try {
+		if (typeof window.Intl !== 'object' && window.Intl !== null) {
+			var locale = ((location.search || '?').substr(1).split('&').find(function(d) { if (!d){ return ''; } else { return d.startsWith('locale'); }}) || 'locale=en-US').split('=')[1];
+			document.write('<script src="https://cdn.polyfill.io/v2/polyfill.js?features=Intl.~locale.' + locale + '"><' + '/script>');
+		}
+	} catch(e) {
+		if (document.location.href.indexOf('msdebug=true') > -1) {
+			console.log('initialize Intl object failed!');
+		}
+	}
+
+</script>
+<div class="parbase clientcontext">
+    <script type="text/javascript">
+    $CQ(function() {
+        CQ_Analytics.SegmentMgr.loadSegments("/etc/segmentation");
+        CQ_Analytics.ClientContextUtils.init("/etc/clientcontext/ms","/content/morningstarcom/en_us/markets/newsDetail");
+
+
+    });
+
+    </script>
+</div>
+<div class="flyout">
+    <div class="menu-button">
+        <button type="button">Menu</button>
+    </div>
+</div>
+<div class="page-wrapper">
+    <div class="page">
+        <header class="on-page" role="banner">
+
+
+            <div class="inner-wrap">
+                <div class="menu-button">
+                    <button type="button">Menu</button>
+                </div>
+                <div class="mstar-logo">
+                    <a href="/"><img src="/etc/designs/morningstar/images/logo/svg/mstar_logo.svg./24939394.svg"
+                                     alt="Morningstar Logo"/></a>
+                </div>
+                <div class="greeting">
+                    <p data-mod="welcome">Welcome!</p>
+                </div>
+                <div class="membership-ad">
+                    <div class="parsys iparsys Parsys-membership-ad">
+                        <div class="iparys_inherited">
+                            <div class="parsys iparsys Parsys-membership-ad"></div>
+                        </div>
+                    </div>
+
+                </div>
+                <div class="top-links-and-search-and-text-ad-container">
+                    <div class="top-links">
+                        <button type="button">Membership</button>
+                        <ul>
+                            <li class="company-site"><a href="http://www.morningstar.com/company/" target="_blank"
+                                                        rel="nofollow">About Morningstar &gt;</a></li>
+                            <li data-usertype="f,fa,p,pa,d,da" class="logout"><a data-mod="logout"
+                                                                                 href="https://www.morningstar.com/members/logout.html"
+                                                                                 rel="nofollow">Logout</a></li>
+                            <li data-usertype="v" class="login"><a href="https://www.morningstar.com/members/login.html"
+                                                                   rel="nofollow">Login</a></li>
+                            <li data-usertype="v,f,fa,d,da" class="subscribe"><a
+                                    href="http://members.morningstar.com/mk/templates/mkpremium1.html?referid=a3009&vurl=#&HID=HPG_LNK101"
+                                    rel="nofollow">Subscribe</a></li>
+                            <li data-usertype="v" class="register"><a
+                                    href="http://members.morningstar.com/mk/templates/mkvisitor1.html?referid=a3009&vurl=#&HID=HPG_LNK100"
+                                    rel="nofollow">Register</a></li>
+                            <li data-usertype="p,pa" class="premium"><a
+                                    href="http://www.morningstar.com/Cover/PremiumLinks.html" rel="nofollow">Premium</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="site-search">
+                        <button type="button">Site Search</button>
+                        <div class="parsys iparsys iParsys-auto-complete">
+                            <div class="section">
+                                <div class="new"></div>
+                            </div>
+                            <div class="iparys_inherited">
+                                <div class="parsys iparsys iParsys-auto-complete">
+                                    <div class="section">
+
+
+                                        <div class="control-wrapper search header-quote-box" data-mod="auto-complete"
+                                             data-init="false"
+                                             data-maxrecord="12"
+                                             data-allowmultiple="true"
+                                             data-settingpath="/etc/morningstarAssets/scaffolding/autocomplete/us"
+                                             data-culture="en_US">
+                                            <label for="qs0">Search Symbols</label>
+                                            <div class="input-wrapper">
+                                                <input type="search" id="qs0" placeholder="Quote" autocomplete="off"/>
+                                                <div class="search-icon"></div>
+                                                <div class="clear-icon"></div>
+                                                <div class="autocomplete-list autocomplete quote"></div>
+                                            </div>
+
+                                        </div>
+
+
+                                    </div>
+                                    <div data-init="false" class="search control-wrapper section header-site-search"
+                                         data-mod="site-search">
+
+
+                                        <label for="ss0">Search The Site</label>
+                                        <div class="input-wrapper">
+                                            <input type="search" id="ss0" placeholder="Search" autocomplete="off"/>
+                                            <div class="search-icon"></div>
+                                            <div class="clear-icon"></div>
+                                            <input type="hidden" value=""/>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+                <div class="banner-house-ads">
+                    <div class="banner-ad">
+                        <div class="parsys Parsys-banner-ad iparsys">
+                            <div class="iparys_inherited">
+                                <div class="parsys Parsys-banner-ad iparsys"></div>
+                            </div>
+                            <div class="adSafeframe section">
+
+
+                                <div class="ad-728x90" data-mod="safeframe" data-name="sfad0" data-dest="sfad0"
+                                     data-pos="top" data-size="728x90" data-w="728" data-h="90" data-viewidoption="1"
+                                     data-custom="" data-refresh="" data-props="language,section,cat">
+                                    <div id="sfad0"></div>
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                    <div class="house-ad">
+                        <div class="parsys iparsys Parsys-house-ad">
+                            <div class="iparys_inherited">
+                                <div class="parsys iparsys Parsys-house-ad"></div>
+                            </div>
+                            <div class="adSafeframe section">
+
+
+                                <div class="ad-195x90" data-mod="safeframe" data-name="sfad1" data-dest="sfad1"
+                                     data-pos="toprightbutton" data-size="195x90" data-w="195" data-h="90"
+                                     data-viewidoption="2" data-custom="" data-refresh=""
+                                     data-props="language,section,cat">
+                                    <div id="sfad1"></div>
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                </div>
+                <nav class="responsiveNavigation" role="navigation">
+
+
+                    <ul class="main">
+
+
+                        <li class="">
+
+                            <a data-usertype="v" class="hidden" href="/membership.html">Join</a>
+
+                            <a data-usertype="f,fa,p,pa,d,da" href="/membership.html">Membership</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class=""><a href="/">Home</a></li>
+
+                        <li class="">
+
+
+                            <a href="/portfolio.html">Portfolio</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/stocks.html">Stocks</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/bonds.html">Bonds</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/funds.html">Funds</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/etfs.html">ETFs</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/cefs.html">CEFs</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="is-selected">
+
+
+                            <a href="/markets.html">Markets</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/tools.html">Tools</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/invest-in-retirement.html">Personal Finance</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                        <li class="">
+
+
+                            <a href="/discuss.html">Discuss</a>
+
+                            <ul class="sub">
+
+
+                            </ul>
+
+                        </li>
+
+
+                    </ul>
+                </nav>
+
+            </div>
+        </header>
+
+
+        <div class="content" role="main">
+            <div class="content-area-main">
+
+                <div class="content-area-1">
+                    <div class="parsys Parsys-1">
+                        <div class="section newsDetail">
+
+
+                            <section class="news-detail-instance small">
+                                <!--news header-->
+                                <div class="news-detail-header">
+
+                                    <div class="provider-logo primary-section-name">
+                                        <ul class="provider-logo-link-list">
+                                            <li>
+                                                <a href="/news/associated-press.html">News: Associated Press</a>
+                                            </li>
+                                            <li>
+                                                <a href="http://www.ap.org/">
+
+                                                    <img src="http://im.mstar.com/news/ap_toplogo.png">
+
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+
+
+                                    <h1 class="title">Hackers break into centralized password manager OneLogin</h1>
+
+                                </div>
+                                <!--news toolbar-->
+
+                                <div class="news-detail-toolbar">
+                                    <div class="parsys parsys-toolbar">
+                                        <div class="newsArticleToolbar section">
+
+
+                                            <script type="text/javascript"
+                                                    src="//s7.addthis.com/js/300/addthis_widget.js#pubid=metherd"></script>
+                                            <section class="news-article-toolbar-container"
+                                                     data-isactiveprint="true"
+                                                     data-isactiveshare="true"
+                                                     data-isactivefontsize="true"
+                                            >
+                                                <div class="actions">
+                                                    <a class="news-button print" href="javascript:void(0)">Print</a>
+                                                    <a class="news-button share" href="javascript:void(0)">Share</a>
+                                                    <a class="news-button font-size"
+                                                       href="javascript:void(0)">Font-size</a>
+                                                </div>
+                                                <div class="clear"/>
+                                            </section>
+                                        </div>
+
+                                    </div>
+
+                                </div>
+
+                                <!--publicationTime-->
+
+                                <div class="news-time-stamp">
+                                    06/02/17 12:02 PM EDT
+                                </div>
+
+                                <!--news content-->
+                                <div class="news-detail-content">
+                                    <block id="Main">
+                                        <p>NEW YORK (AP) — Hackers have gained access to OneLogin, an online password
+                                            manager that offers a single sign-on to multiple websites and services.</p>
+
+                                        <div class="parsys parsys-mid-ad">
+                                            <div class="adSafeframe section">
+
+
+                                                <div class="ad-300x250" data-mod="safeframe" data-name="sfad2"
+                                                     data-dest="sfad2" data-pos="middle" data-size="300x250"
+                                                     data-w="300" data-h="250" data-viewidoption="1" data-custom=""
+                                                     data-refresh="" data-props="language,section,cat">
+                                                    <div id="sfad2"></div>
+                                                </div>
+                                            </div>
+
+                                        </div>
+
+
+                                        <p>OneLogin disclosed the hack in a blog post but didn't specify the data
+                                            accessed in the breach.</p>
+                                        <p>Published reports, however, say OneLogin informed customers that the hackers
+                                            appeared to have gotten a way to access encrypted data. Passwords are
+                                            typically stored that way.</p>
+                                        <p>OneLogin didn't immediately respond to an inquiry.</p>
+                                        <p>Password managers help people keep track of passwords for a growing array of
+                                            websites and services that require one. Instead of having to remember
+                                            complex passwords for each one, people can just remember a master password.
+                                            The password service then unlocks other accounts as needed.</p>
+                                        <p>In 2015, rival LastPass said hackers obtained some user information —
+                                            although not actual passwords.</p>
+                                    </block>
+                                </div>
+                                <div class="clear">
+                                    <!--NewsAPIResourceID="urn:publicid:ap.org:f8d53c4370434744a864d4afa5fa8d36"--></div>
+                            </section>
+                        </div>
+                        <div class="newsArticleToolbar section">
+
+
+                            <script type="text/javascript"
+                                    src="//s7.addthis.com/js/300/addthis_widget.js#pubid=metherd"></script>
+                            <section class="news-article-toolbar-container"
+                                     data-isactiveprint="true"
+                                     data-isactiveshare="true"
+                                     data-isactivefontsize="true"
+                            >
+                                <div class="actions">
+                                    <a class="news-button print" href="javascript:void(0)">Print</a>
+                                    <a class="news-button share" href="javascript:void(0)">Share</a>
+                                    <a class="news-button font-size" href="javascript:void(0)">Font-size</a>
+                                </div>
+                                <div class="clear"/>
+                            </section>
+                        </div>
+
+                    </div>
+
+                </div>
+
+                <div class="content-area-2">
+                    <div class="parsys Parsys-2">
+                        <div class="adSafeframe section">
+
+
+                            <div class="ad-65-chartextlink" data-mod="safeframe" data-name="sfad3" data-dest="sfad3"
+                                 data-pos="toplink" data-size="65-chartextlink" data-w="300" data-h="50"
+                                 data-viewidoption="2" data-custom="" data-refresh="" data-props="language,section,cat">
+                                <div id="sfad3"></div>
+                            </div>
+                        </div>
+                        <div class="adSafeframe section">
+
+
+                            <div class="ad-300x250" data-mod="safeframe" data-name="sfad4" data-dest="sfad4"
+                                 data-pos="topright" data-size="300x250,300x600" data-w="300" data-h="250"
+                                 data-multisize='true' data-viewidoption="1" data-custom="" data-refresh=""
+                                 data-props="language,section,cat">
+                                <div id="sfad4"></div>
+                            </div>
+                        </div>
+                        <div class="adSafeframe section">
+
+
+                            <div class="ad-65-chartextlink" data-mod="safeframe" data-name="sfad5" data-dest="sfad5"
+                                 data-pos="toplink" data-size="65-chartextlink" data-w="300" data-h="50"
+                                 data-viewidoption="2" data-custom="" data-refresh="" data-props="language,section,cat">
+                                <div id="sfad5"></div>
+                            </div>
+                        </div>
+                        <div class="adSafeframe section">
+
+
+                            <div class="ad-contentmodule" data-mod="safeframe" data-name="sfad6" data-dest="sfad6"
+                                 data-pos="right" data-size="contentmodule" data-w="370" data-h="626"
+                                 data-multisize='true' data-viewidoption="2" data-custom="" data-refresh=""
+                                 data-props="language,section,cat">
+                                <div id="sfad6"></div>
+                            </div>
+                        </div>
+                        <section class="header-footer primary-section ads-container section">
+
+
+                            <header>
+
+
+                                <h1 class="primary-section-name">
+
+
+                                    Sponsored Links
+
+
+                                </h1>
+
+
+                            </header>
+                            <div class="clear-header"></div>
+
+
+                            <div class="sponsor-center">
+                                <div class="parsys ads-parsys">
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-sponsorlink" data-mod="safeframe" data-name="sfad7"
+                                             data-dest="sfad7" data-pos="SC1" data-size="sponsorlink" data-w="300"
+                                             data-h="100" data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad7"></div>
+                                        </div>
+                                    </div>
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-sponsorlink" data-mod="safeframe" data-name="sfad8"
+                                             data-dest="sfad8" data-pos="SC2" data-size="sponsorlink" data-w="300"
+                                             data-h="100" data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad8"></div>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                            </div>
+
+
+                        </section>
+                        <section class="header-footer primary-section ads-container section">
+
+
+                            <header>
+
+
+                                <h1 class="primary-section-name">
+
+
+                                    Sponsor Center
+
+
+                                </h1>
+
+
+                            </header>
+                            <div class="clear-header"></div>
+
+
+                            <div class="sponsor-center">
+                                <div class="parsys ads-parsys">
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-120x60" data-mod="safeframe" data-name="sfad9" data-dest="sfad9"
+                                             data-pos="SC1" data-size="120x60" data-w="120" data-h="60"
+                                             data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad9"></div>
+                                        </div>
+                                    </div>
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-120x60" data-mod="safeframe" data-name="sfad10"
+                                             data-dest="sfad10" data-pos="SC2" data-size="120x60" data-w="120"
+                                             data-h="60" data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad10"></div>
+                                        </div>
+                                    </div>
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-120x60" data-mod="safeframe" data-name="sfad11"
+                                             data-dest="sfad11" data-pos="SC3" data-size="120x60" data-w="120"
+                                             data-h="60" data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad11"></div>
+                                        </div>
+                                    </div>
+                                    <div class="adSafeframe section">
+
+
+                                        <div class="ad-120x60" data-mod="safeframe" data-name="sfad12"
+                                             data-dest="sfad12" data-pos="SC4" data-size="120x60" data-w="120"
+                                             data-h="60" data-viewidoption="2" data-custom="" data-refresh=""
+                                             data-props="language,section,cat">
+                                            <div id="sfad12"></div>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                            </div>
+
+
+                        </section>
+
+                    </div>
+
+                </div>
+            </div>
+        </div>
+        <footer class="footer-component" role="contentinfo">
+
+
+            <div class="foot-ad-parsys adSafeframe">
+                <div class="ad-728x90">
+                    <div class="parsys Parsys-footer-ad">
+                    </div>
+
+                </div>
+            </div>
+            <div class="parsys iparsys Parsys-footer">
+                <div class="iparys_inherited">
+                    <div class="parsys iparsys Parsys-footer"></div>
+                </div>
+                <div class="adSafeframe section">
+
+
+                    <div class="ad-728x90" data-mod="safeframe" data-name="sfad13" data-dest="sfad13" data-pos="bottom"
+                         data-size="728x90" data-w="728" data-h="90" data-viewidoption="2" data-custom=""
+                         data-refresh="" data-props="language,section,cat">
+                        <div id="sfad13"></div>
+                    </div>
+                </div>
+
+                <p class="miscellaneous"><a href="http://news.morningstar.com/Corrections/CorrectionsList.html">Corrections</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstar.com/Cover/Help.html">Help</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstar.com/AboutUs/MediaKit.html">Advertising Opportunities</a>&nbsp;&nbsp;<a
+                        href="http://members.morningstar.com/reprints/rp_home.html">Licensing</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstar.com/topics">Topics</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstaradvisor.com/">MorningstarAdvisor</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstar.com/InvGlossary/">Glossary</a>&nbsp;&nbsp;<a
+                        href="http://news.morningstar.com/rss/rss.html">RSS</a>&nbsp;&nbsp;<a
+                        href="http://www.morningstar.com/products/Store_StoreCoverPage.html">Store</a>&nbsp;&nbsp;<a
+                        href="http://members.morningstar.com/memberstpages/Morningstar_Affiliate.html">Affiliate</a>&nbsp;&nbsp;<a
+                        href="http://corporate.morningstar.com/US/asp/subject.aspx?xmlfile=361.xml">Careers</a>&nbsp;&nbsp;<a
+                        href="http://corporate.morningstar.com/US/asp/home.aspx?xmlfile=202.xml&amp;pgid=hetopcompsite">Company
+                    Site</a></p>
+
+
+                <div class="internationalSites section">
+
+
+                    <div class="international-sites">
+                        <ul>
+                            <li><a class="category">International Sites</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.com.au/">Australia</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.ca/">Canada</a></li>
+                            <li class="hidden"><a href="http://www.cn.morningstar.com/main/default.aspx" rel="nofollow">China</a>
+                            </li>
+                            <li class="hidden"><a href="http://www.morningstar.fr/" rel="nofollow">France</a></li>
+                            <li class="hidden"><a href="http://www.morningstarfonds.de/de/default.aspx?lang=de-DE"
+                                                  rel="nofollow">Germany</a></li>
+                            <li class="hidden"><a href="http://www.hk.morningstar.com/" rel="nofollow">Hong Kong</a>
+                            </li>
+                            <li class="hidden"><a href="http://www.morningstar.it/it/default.aspx?lang=it-IT"
+                                                  rel="nofollow">Italy</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.nl/nl/default.aspx?lang=nl-NL"
+                                                  rel="nofollow">The Netherlands</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.no/" rel="nofollow">Norway</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.es/es/default.aspx?lang=es-ES"
+                                                  rel="nofollow">Spain</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.co.uk/uk/default.aspx">U.K.</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.ch/" rel="nofollow">Switzerland</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.in/" rel="nofollow">India</a></li>
+                            <li class="hidden"><a href="http://www.morningstar.fi/" rel="nofollow">Finland</a></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <p
+                        class="legal">Independent. Insightful. Trusted. Morningstar provides stock market analysis;
+                    equity, mutual fund, and ETF research, ratings, and picks; portfolio tools; and IRA, 401k, and 529
+                    plan research. Our reliable data and analysis can help both experienced enthusiasts and
+                    newcomers.<br/>
+                    <br/>
+                    &copy; Copyright 2016 Morningstar, Inc. All rights reserved. Please read our <a
+                            href="http://www.morningstar.com/AboutUs/copyright.html">Terms of Use</a> and <a
+                            href="http://members.morningstar.com/memberstpages/PrivacyPolicy.html">Privacy Policy. </a>Dow
+                    Jones Industrial Average, S&amp;P 500, Nasdaq, and Morningstar Index (Market Barometer) quotes are
+                    real-time.</p>
+
+
+            </div>
+        </footer>
+
+    </div>
+</div>
+<input type="hidden" id="pageLanguageCode" value="en_US"/>
+
+
+<div id="adsense"><img/></div>
+<script type="text/javascript" src="/etc/morningstarFoundations/v2/clientlibs/msiip-core.min.1495651899039.js"></script>
+<link rel="stylesheet" href="/etc/morningstarFoundations/v2/clientlibs/msiip-user.min.1495651899039.css"
+      type="text/css">
+<script type="text/javascript" src="/etc/designs/morningstar/v2/clientlibs/msiip-user.min.1495651899039.js"></script>
+<script type="text/javascript"
+        src="/etc/morningstarFoundations/v2/clientlibs/msiip-angular.min.1495651899039.js"></script>
+<link rel="stylesheet" href="/etc/designs/morningstar/bodylib.min.1495651899039.css" type="text/css">
+<script type="text/javascript" src="/etc/morningstarFoundations/v2/libs/angular-1.3.15.min.1495651899039.js"></script>
+<script type="text/javascript" src="/etc/designs/morningstar/v2/libs/uim.global-1.0.0.min.1495651899039.js"></script>
+<script type="text/javascript" src="/etc/designs/morningstar/bodylib.min.1495651899039.js"></script>
+<script>
+	try {
+		_satellite.pageBottom();
+	} catch(e) {
+		msind.Debug.log('pageBottom', e);
+	}
+	$(document).ready(function () {
+		// Set build version
+		NS('msind.Data').BuildVersion = '3.14.0-SNAPSHOT';
+	});
+
+</script>
+</body>
+</html>

--- a/src/test/resources/de/jetwick/snacktory/sfchronicle.html
+++ b/src/test/resources/de/jetwick/snacktory/sfchronicle.html
@@ -1,0 +1,1646 @@
+
+<!-- hearst/home/commentsInit.tpl -->
+
+<!-- e hearst/home/commentsInit.tpl --><!DOCTYPE html>
+
+<!-- hearst/article/article_header.tpl -->
+<html>
+<head><!-- eid:article.6541824 --><!--[if IE 8]>
+    <meta http-equiv="x-ua-compatible" content="IE=7">
+    <![endif]-->
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <!-- generated at 2017-06-05 01:08:34 on p-pwcm4 running vr8.9.1.1 -->
+    <meta name="viewport" content="initial-scale = 1.0, maximum-scale = 1.0, width = device-width">
+    <!-- Hotfix Top freeform -->
+
+    <!-- hearst/item/standalone.tpl -->
+    <!-- mid:freeform.78644 -->
+
+    <link rel="stylesheet" type="text/css" href="/external/css/global.article_global.r8.9.1.1.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/external/css/global.article_local.r8.9.1.1.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/external/css/global.ie8.r8.9.1.1.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/external/css/global.article_print.r8.9.1.1.css" media="all" />
+    <script type="text/javascript" src="/js/hdn/utils/jquery-1.11.1.min.js"></script>
+    <!-- hmb:isa_header  include static asset for group js header  -->
+    <script type="text/javascript" src="/external/js/global.header.r8.9.1.1.js"></script>
+    <!-- includeCssJsFromFileObject no file object with code: specialproject/js/article/ in siteId: 35 -->
+    <script type="text/javascript" src="//treg.hearstnp.com/treg.js"></script>
+    <!-- hearst/common/omniture.tpl -->
+    <script type="text/javascript">
+    // <![CDATA[
+    // document.domain = "hearstnp.com";
+    var requestTime = new Date(1496642914 * 1000);
+
+                                
+                    
+                    
+        
+        // bizobject variables
+        var omni_channelPath = "Biz & Tech";
+                var omni_title = "Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club";
+                var omni_bizObjectId = "6541824";
+        var omni_className = "article";
+        var omni_publicationDate = "2015-10-01 23:16:35";
+        var omni_sourceSite="sfgate";
+
+                            // article specific variables
+            var omni_authorName = "By Carolyn Said";
+            var omni_authorTitle = "";
+            var omni_pageNumber = "1";
+            var omni_breakingNewsFlag = "0";
+            var omni_localNewsFlag = "1";
+            var omni_premiumStatus = "isPremium";
+            var omni_premiumEndDate = "2030-01-01 08:00:00";
+            var omni_originalSource = "SF";
+            var omni_isListView = "0";
+                    
+        var omni_paywallSite = "1";
+
+        // ]]>
+</script>
+
+    <!--[if IE 6]><script type="text/javascript" src="/js/hdn/utils/DD_belatedPNG_0.0.8a-min.js"></script><![endif]-->
+    <!-- e hearst/common/omniture.tpl -->        <!-- Fix for ad blocker plus - needs to be placed before include of juice -->
+    <script type="text/javascript">function hearstPlaceAd(){}</script>
+    <!-- hmb:jsadPositionManager js for adPositionManager (loadAds.js) -->
+    <script type="text/javascript" id="adPositionManagerScriptTag" src="http://aps.hearstnp.com/Scripts/loadAds.js"></script>
+
+    <!--[if lt IE 9]>
+    <script src="/js/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- Bing Webmaster Tools verification -->
+    <meta name="msvalidate.01" content="9451CA04ABC9D1D5C6419C73B4C4F7B7" />
+    <meta property="fb:admins" content="100006394927810"/>
+    <title>Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club - San Francisco Chronicle</title>
+    <link rel="SHORTCUT ICON" href="/favicon.ico?v=3" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon-precomposed.png"/>
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72-precomposed.png"/>
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114-precomposed.png"/>
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144-precomposed.png"/>
+    <link rel="canonical" href="http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php" /><link rel="amphtml" href="http://www.sfchronicle.com/business/amp/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php" />
+    <meta name="description" content="San Francisco’s Thumbtack, which introduces fix-it folks, caterers, yoga teachers and other professionals to people who need them, vaulted into the unicorn club this week after a $125 million funding round put its valuation at $1.3 billion.  “Our vision is to replace and reimagine a big chunk of the Yellow Pages,” said CEO Marco Zappacosta, who co-founded Thumbtack in 2009 after what he called a banal observation:  Thumbtack lets customers describe a job — anything from painting a house to walking a dog — with lots of specifics, including location, timing and budget.  After the initial introduction, Thumbtack bows out of the relationship, although at some point it might add optional back-end services such as a scheduling platform and payment system, he said.  Home improvement, Thumbtack’s biggest category, is a lucrative and highly fragmented market worth well over $500 million annually in the United States.  “Thumbtack sends us exactly what customers are looking for,” said Geraldine Chiaramonte, who runs Bay Area Candy Buffet, providing sweet treats for weddings and other occasions.  [...] could Thumbtack grow as big as Google? “I don’t want to sound too over-the-top, but the local services market is much larger than the online advertising market,” Schreier said.  Zappacosta said its less-controversial status drew Republican presidential candidate Jeb Bush, who rode in an Uber to Thumbtack for a heavily publicized campaign stop in July, shortly after Democratic front-runner Hillary Rodham Clinton criticized the gig economy’s lack of worker protections." />
+    <meta name="author.name" content="By Carolyn Said" />
+    <meta name="author.title" content="" />
+    <meta name="date.release" content="2015/01/10" />
+    <meta name="time.release" content="16:16" />
+    <meta name="publisher" content="San Francisco Chronicle" />
+    <meta name="sections" content="Business" />
+    <meta name="subject" content="family,investments,marriage,consumers,employee,restaurant and catering" />
+    <meta name="news_keywords" content="thumbtack,gig economy,service,unicorn club,traditional ecommerce site,online advertising market,information,gig economy services,Italian cooking lessons,business,customer service,zappacosta,worker protections,market,referral service,services market,funding,service providers,employees,homerepairs offerings,family" />
+    <meta name="tmeconcepts" content="thumbtack,gig economy,service,unicorn club,traditional ecommerce site,online advertising market,information,gig economy services,Italian cooking lessons,business,customer service,zappacosta,worker protections,market,referral service,services market,funding,service providers,employees,homerepairs offerings" />
+    <meta name="tmecategories" content="family" />
+
+    <script type="text/javascript" src="/js/hdn/omniture/video.js"></script>
+    <!-- ux hearst/home/header_sailthru.tpl -->
+    <meta property="sailthru.title" content="Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club" /><meta name="sailthru.date" content="2015-10-01 16:16:00 -0700" /><meta name="sailthru.author" content="By Carolyn Said" /><meta name="sailthru_type" content="article" /><meta name="sailthru_uid" content="6541824" /><meta name="sailthru_section" content="business" /><meta name="sailthru_subject" content="technology,home-services,marketplaces,plumbers,service-professionals,home-improvement" /><meta name="sailthru_pubname" content="san-francisco-chronicle" /><meta name="sailthru_siteid" content="35" /><meta name="sailthru.tags" content="business,technology,home-services,marketplaces,plumbers,service-professionals,home-improvement,san-francisco-california,marco-zappacosta,thumbtack,gig-economy,service,unicorn-club,traditional-e-commerce-site,online-advertising-market,information,gig-economy-services,italian-cooking-lessons,customer-service,zappacosta" /><meta name="sailthru_isPremium" content="true" /><meta name="sailthru.image.thumb" content="http://ww4.hdnux.com/photos/35/76/04/7856403/13/sailthruImage.jpg" />
+    <!-- e ux hearst/home/header_sailthru.tpl -->
+    <!-- hearst/common/sailthruJS.tpl -->
+    <!-- hmb:jssailthru js for SailThru -->
+    <script language="javascript" type="text/javascript" src="//ak.sail-horizon.com/onsite/personalize.v0.0.4.min.js" data-sailthru-setup="true"></script>
+    <script type="text/javascript">
+    $(function() {
+        if (window.Sailthru) {
+            Sailthru.SPM.setup("fca2a0390286f0e53120a668534d9529", {autoTrackPageViews: false, useStoredTags: true});
+            Sailthru.SPM.trackPageView("http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php");
+        }
+    });
+</script>
+    <!-- e hearst/common/sailthruJS.tpl -->
+
+    <meta property="og:title" content="Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club" />
+    <meta property="og:description" content="San Francisco’s Thumbtack, which introduces fix-it folks, caterers, yoga teachers and other professionals to people who need them, vaulted into the unicorn club this week after a $125 million funding round put its valuation at $1.3 billion.  “Our vision is to replace and reimagine a big chunk of the Yellow Pages,” said CEO Marco Zappacosta, who co-founded Thumbtack in 2009 after what he called a banal observation:  Thumbtack lets customers describe a job — anything from painting a house to walking a dog — with lots of specifics, including location, timing and budget.  After the initial introduction, Thumbtack bows out of the relationship, although at some point it might add optional back-end services such as a scheduling platform and payment system, he said.  Home improvement, Thumbtack’s biggest category, is a lucrative and highly fragmented market worth well over $500 million annually in the United States.  “Thumbtack sends us exactly what customers are looking for,” said Geraldine Chiaramonte, who runs Bay Area Candy Buffet, providing sweet treats for weddings and other occasions.  [...] could Thumbtack grow as big as Google? “I don’t want to sound too over-the-top, but the local services market is much larger than the online advertising market,” Schreier said.  Zappacosta said its less-controversial status drew Republican presidential candidate Jeb Bush, who rode in an Uber to Thumbtack for a heavily publicized campaign stop in July, shortly after Democratic front-runner Hillary Rodham Clinton criticized the gig economy’s lack of worker protections." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php" />
+
+    <meta property="og:image" content="http://ww4.hdnux.com/photos/35/76/04/7856403/13/rawImage.jpg" />
+    <meta property="og:site_name" content="San Francisco Chronicle" />
+    <!-- Twitter card metadata  -->
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sfchronicle" />
+    <meta name="twitter:creator" content="@Csaid" />
+
+    <!-- /business/templates/hearst/home/header_fbpage.tpl-->
+
+
+    <meta property="fb:app_id" content="537896802938133"/>
+
+    <!-- e /business/templates/hearst/home/header_fbpage.tpl-->    <!-- templates/hearst/home/viafouraHeadMeta.tpl -->
+    <meta property="vf:unique_id" content="premiumsfgate-article-6541824" />
+    <meta property="vf:section" content="business">
+    <!-- e templates/hearst/home/viafouraHeadMeta.tpl --><!-- CSS/JS Hotfix freeform - all premium -->
+    <!-- hearst/item/standalone.tpl -->
+    <!-- mid:freeform.46358 -->
+
+    <!-- CSS/JS Hotfix freeform -->
+
+    <!-- hearst/item/standalone.tpl -->
+    <!-- mid:freeform.14699 -->
+
+    <meta name='__sync_contentCategory' content='meterA' />
+
+    <script type='text/javascript' src='https://syncaccess-hst-sfc.syncronex.com/hst/sfc/api/scripts/syncwall'></script>
+
+
+    <!-- hearst/common/hdn_datalayer_header.tpl -->
+    <script type="text/javascript">
+    // <![CDATA[
+
+        HDN = HDN || {};
+        HDN.dataLayer = HDN.dataLayer || {};
+
+        // HDN.dataLayer object for content and href data
+        HDN.dataLayer.content = HDN.dataLayer.content || {};
+        HDN.dataLayer.href = HDN.dataLayer.href || {};
+
+    
+        
+            HDN.dataLayer.content.title = "Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club";
+                HDN.dataLayer.content.subtitle = "";
+        HDN.dataLayer.content.objectId = "6541824";
+        HDN.dataLayer.content.objectType = "article";
+        
+        HDN.dataLayer.content.sectionPath = ['business'];
+        HDN.dataLayer.content.pubDate = "2015-10-01 23:16:35";
+        HDN.dataLayer.content.lastModifiedDate = "2015-10-01 23:18:12";
+        HDN.dataLayer.content.wordCount = 0;
+        HDN.dataLayer.content.keywords = [];
+        HDN.dataLayer.content.keySubjects = ['TECHNOLOGY','HOME SERVICES','MARKETPLACES','PLUMBERS','SERVICE PROFESSIONALS','HOME IMPROVEMENT'];
+        HDN.dataLayer.content.keyPersons = [];
+        HDN.dataLayer.content.keyOrganizations = [];
+        HDN.dataLayer.content.keyConcepts = ['thumbtack','gig economy','service','unicorn club','traditional ecommerce site','online advertising market','information','gig economy services','Italian cooking lessons','business','customer service','zappacosta','worker protections','market','referral service','services market','funding','service providers','employees','homerepairs offerings'];
+        HDN.dataLayer.content.keyCategories = ['family'];
+        HDN.dataLayer.content.keyPlaces = [];
+
+        // HDN.dataLayer object for source information
+        HDN.dataLayer.source = HDN.dataLayer.source || {};
+
+        HDN.dataLayer.source.authorName = "By Carolyn Said";
+        HDN.dataLayer.source.authorTitle = "";
+        HDN.dataLayer.source.originalSourceSite = "SF";
+        HDN.dataLayer.source.publishingSite = "premiumsfgate";
+        HDN.dataLayer.source.sourceSite = "sfgate";
+        
+
+                    // HDN.dataLayer object for sharing information
+            HDN.dataLayer.sharing = HDN.dataLayer.sharing || {};
+
+            
+                HDN.dataLayer.sharing.openGraphUrl = "http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php";
+        HDN.dataLayer.sharing.openGraphType = "article";
+
+
+        HDN.dataLayer.href.pageUrl = "http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php";
+        HDN.dataLayer.href.canonicalUrl = "http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php";
+        HDN.dataLayer.href.pageUrlPath = window.location.pathname;
+        HDN.dataLayer.href.pageUrlPathFolders = window.location.pathname.replace(/[A-Za-z0-9-_.]+$/, '');
+        HDN.dataLayer.href.pageUrlQueryParams = window.location.search.replace(/^\?/, '');
+        HDN.dataLayer.href.pageUrlHash = window.location.hash;
+
+        // HDN.dataLayer object for presentation information
+        HDN.dataLayer.presentation = HDN.dataLayer.presentation || {};
+
+        
+        HDN.dataLayer.presentation.hasSlideshow = "";
+        HDN.dataLayer.presentation.hasSlideshowListView = "";
+        HDN.dataLayer.presentation.hasVideo = "";
+        HDN.dataLayer.presentation.hasInteractive = "1";
+
+    
+    // ]]>
+</script>
+    <!-- e hearst/common/hdn_datalayer_header.tpl -->
+
+    <!-- hearst/ensighten/ensighten.tpl -->
+    <!-- hearst/ensighten/ensighten.tpl -->
+    <!-- hmb:ensighten Ensighten script -->
+
+    <!-- Hearst analytics: Ensighten -->
+    <script type="text/javascript">
+  (function(e) { 
+    var t = '//nexus.ensighten.com/hearst/news/Bootstrap.js'; 
+    if (e.cookie.indexOf("nsghtn") > -1) {
+      if(e.cookie.indexOf("nsghtn=test-dev") > -1) {
+      console.log("Ensighten :: Test-Dev"); t = "//nexus-test.ensighten.com/hearst/news-dev/Bootstrap.js";
+      } else if(e.cookie.indexOf("nsghtn=test") > -1) {
+      console.log("Ensighten :: Test"); t = "//nexus-test.ensighten.com/hearst/news/Bootstrap.js";
+      } else if(e.cookie.indexOf("nsghtn=dev") > -1) {
+      console.log("Ensighten :: Dev"); t = "//nexus.ensighten.com/hearst/news-dev/Bootstrap.js";
+      } 
+    }
+    e.write("<scr"+"ipt src='"+e.location.protocol+t+"'></"+"scr"+"ipt>");
+  })(document); 
+</script>
+    <!-- End Hearst analytics: Ensighten -->
+
+    <!-- e ensighten.tpl -->    <!-- e hearst/ensighten/ensighten.tpl -->
+</head>
+<body id="home" class=" business">
+<!-- Begin Hearst Ad -->
+<div id="OOP">
+    <script type="text/javascript">/*<![CDATA[*/hearstPlaceAd("OOP");/*]]>*/</script>
+</div>
+<!-- End Hearst Ad -->
+<div id="container" class="article_page">
+    <!-- src/business/templates/hearst/home/premium_header_branding.tpl -->
+    <div id="header">   <!-- ux/premiumsfgate/templates/hearst/common/admin_bar.tpl -->
+        <div class="header-top">
+            <ul class="ht-links">
+                <li class="ht-link-item ht-branding"><a href="//www.sfgate.com/" target="_blank"></a></li>
+                <li class="ht-link-item first"><a href="//www.sfgate.com/cars/" target="_blank">Autos</a></li>
+                <li class="ht-link-item"><a href="//www.sfgate.com/jobs/" target="_blank">Jobs</a></li>
+                <li class="ht-link-item"><a href="//www.sfgate.com/realestate/" target="_blank">Real Estate</a></li>
+                <li class="ht-weather">
+        <span>
+          <a class="weather-ico" href="/weather" target="_blank"></a>
+          <a class="ht-temp" href="/weather" target="_blank"></a>
+        </span>
+                </li>
+            </ul>
+
+
+
+            <ul class="ht-right-links">
+                <li class="ht-ed"><span><a href="/e-edition/" target="_blank">e-edition</a></span></li>
+                <li class="ht-saved"><span><a href="//www.sfchronicle.com/subscribe" target="_blank">Subscribe</a></span></li>
+                <!-- Gigya signin -->
+                <li class="treg-is-gigya gigya_menu">
+                    <div class="gya-title expandable treg-conditional treg-not-logged-in"><span>Sign In</span></div>
+                    <div class="gya-title expandable treg-conditional treg-logged-in"><span></span></div>
+                    <div class="gya-content expandable">
+                        <div class="treg-gya-login-widget"></div>
+                    </div> <!-- /.gya-content -->
+                </li>
+            </ul>
+
+
+
+        </div>
+        <!-- e ux/premiumsfgate/templates/hearst/common/admin_bar.tpl -->
+        <div class="header-branding section">
+            <div class="menu-btn">
+                <a id="menuBtn" class="hdn-analytics" data-hdn-analytics="visit|hamburger-menu|hamburger-menu|0"></a>
+            </div>
+            <div class="wrap-center">
+                <a class="logo-link" href="/"></a>
+                <h1 class="section-title">
+                    <a class="color-link" href="/business/">
+                        Biz & Tech
+                    </a>
+                </h1>
+            </div>
+        </div>
+        <!-- END src/business/templates/hearst/home/premium_header_branding.tpl -->
+        <!-- business/templates/hearst/home/HNavigation.tpl -->
+        <!-- hearst/home/navigation.tpl -->
+        <!-- src/business/templates/hearst/home/premium_navigation_main.tpl -->
+
+        <!-- src/business/templates/hearst/common/premium_dynamic_nav.tpl -->
+
+
+        <div id="navMenu" class="nav-menu">
+            <div class="nav-search">
+
+                <form class="search-form" action="/search/" method="get">
+                    <input type="hidden" name="action" value="search" />
+                    <input type="hidden" name="firstRequest" value="1" />
+                    <input type="hidden" name="searchindex" value="gsa" />
+                    <fieldset>
+                        <input class="form-input" id="search" name="query" type="text" value="" placeholder="Search" />
+                        <input class="search-btn" value="" name="search" type="submit" />
+                    </fieldset>
+                </form>
+            </div>
+            <ul class="nav-menu-list">
+                <li id="nav-menu-link-1422" class="menu-item childless">
+                    <div class="nav-label">
+                        <a href="/" class="hdn-analytics" data-hdn-analytics="visit|Home|navigation|1">
+                            <span class="section-link" data-naveid="1422">Home</span>
+                        </a>
+                    </div>
+                </li>
+                <li id="nav-menu-link-3920" class="menu-item childless">
+                    <div class="nav-label">
+                        <a href="http://www.sfgate.com/" class="hdn-analytics" data-hdn-analytics="visit|SFGATE|navigation|2">
+                            <span class="section-link" data-naveid="3920">SFGATE</span>
+                        </a>
+                    </div>
+                </li>
+                <li id="nav-menu-link-1355" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/local/" class="hdn-analytics" data-hdn-analytics="visit|Local|navigation|3">
+                            <span class="section-link" data-naveid="1355">Local</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="http://www.sfchronicle.com/pot-legalization/" class="hdn-analytics" data-hdn-analytics="visit|Local-Pot Legalization|navigation|1">
+                                <div class="nav-label" data-naveid="4038">Pot Legalization</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/local/columnists/" class="hdn-analytics" data-hdn-analytics="visit|Local-Columnists|navigation|2">
+                                <div class="nav-label" data-naveid="1578">Columnists</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/local/sanfrancisco/" class="hdn-analytics" data-hdn-analytics="visit|Local-San Francisco|navigation|3">
+                                <div class="nav-label" data-naveid="3168">San Francisco</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/local/bayarea/" class="hdn-analytics" data-hdn-analytics="visit|Local-Bay Area|navigation|4">
+                                <div class="nav-label" data-naveid="1397">Bay Area</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/local/crime/" class="hdn-analytics" data-hdn-analytics="visit|Local-Crime|navigation|5">
+                                <div class="nav-label" data-naveid="1400">Crime</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/politics/" class="hdn-analytics" data-hdn-analytics="visit|Local-Politics|navigation|6">
+                                <div class="nav-label" data-naveid="3584">Politics</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/oakland-fire/" class="hdn-analytics" data-hdn-analytics="visit|Local-Oakland Ghost Ship fire|navigation|7">
+                                <div class="nav-label" data-naveid="4212">Oakland Ghost Ship fire</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.legacy.com/obituaries/sfgate/" class="hdn-analytics" data-hdn-analytics="visit|Local-Obituaries|navigation|8">
+                                <div class="nav-label" data-naveid="1460">Obituaries</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/drought/" class="hdn-analytics" data-hdn-analytics="visit|Local-California Drought|navigation|9">
+                                <div class="nav-label" data-naveid="3362">California Drought</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-1356" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/us-world/" class="hdn-analytics" data-hdn-analytics="visit|US & World|navigation|4">
+                            <span class="section-link" data-naveid="1356">US & World</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/us-world/us/" class="hdn-analytics" data-hdn-analytics="visit|US & World-US|navigation|1">
+                                <div class="nav-label" data-naveid="1402">US</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/us-world/world/" class="hdn-analytics" data-hdn-analytics="visit|US & World-World|navigation|2">
+                                <div class="nav-label" data-naveid="1403">World</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/politics/" class="hdn-analytics" data-hdn-analytics="visit|US & World-Politics|navigation|3">
+                                <div class="nav-label" data-naveid="4208">Politics</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/us-world/science/" class="hdn-analytics" data-hdn-analytics="visit|US & World-Science|navigation|4">
+                                <div class="nav-label" data-naveid="1406">Science</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-1411" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/opinion/" class="hdn-analytics" data-hdn-analytics="visit|Opinion|navigation|5">
+                            <span class="section-link" data-naveid="1411">Opinion</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/opinion/editorials/" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Editorials|navigation|1">
+                                <div class="nav-label" data-naveid="1412">Editorials</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/opinion/letters-editor/" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Letters to the editor|navigation|2">
+                                <div class="nav-label" data-naveid="1413">Letters to the editor</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/opinion/op-ed-columns/" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Op-ed columns|navigation|3">
+                                <div class="nav-label" data-naveid="1414">Op-ed columns</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/opinion/insight/" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Insight|navigation|4">
+                                <div class="nav-label" data-naveid="1466">Insight</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/openforum/" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Open Forum|navigation|5">
+                                <div class="nav-label" data-naveid="3737">Open Forum</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/opinion/article/submit-your-opinion-7244189.php?t=3678db0449" class="hdn-analytics" data-hdn-analytics="visit|Opinion-Submit your opinions|navigation|6">
+                                <div class="nav-label" data-naveid="3751">Submit your opinions</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-1358" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/sports/" class="hdn-analytics" data-hdn-analytics="visit|Sports|navigation|6">
+                            <span class="section-link" data-naveid="1358">Sports</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/sports/49ers/" class="hdn-analytics" data-hdn-analytics="visit|Sports-49ers|navigation|1">
+                                <div class="nav-label" data-naveid="1360">49ers</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/raiders/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Raiders|navigation|2">
+                                <div class="nav-label" data-naveid="1361">Raiders</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/giants/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Giants|navigation|3">
+                                <div class="nav-label" data-naveid="1362">Giants</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/athletics/" class="hdn-analytics" data-hdn-analytics="visit|Sports-A's|navigation|4">
+                                <div class="nav-label" data-naveid="1363">A's</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/warriors/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Warriors|navigation|5">
+                                <div class="nav-label" data-naveid="1364">Warriors</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/cal_sports/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Cal|navigation|6">
+                                <div class="nav-label" data-naveid="3595">Cal</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/high-school/" class="hdn-analytics" data-hdn-analytics="visit|Sports-High School|navigation|7">
+                                <div class="nav-label" data-naveid="1369">High School</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/stanford_sports/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Stanford|navigation|8">
+                                <div class="nav-label" data-naveid="3596">Stanford</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/sharks/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Sharks|navigation|9">
+                                <div class="nav-label" data-naveid="1366">Sharks</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/outdoors/" class="hdn-analytics" data-hdn-analytics="visit|Sports-Outdoors|navigation|10">
+                                <div class="nav-label" data-naveid="1375">Outdoors</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/sports/college/" class="hdn-analytics" data-hdn-analytics="visit|Sports-College|navigation|11">
+                                <div class="nav-label" data-naveid="1365">College</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-1407" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/business/" class="hdn-analytics" data-hdn-analytics="visit|Biz & Tech|navigation|7">
+                            <span class="section-link" data-naveid="1407">Biz & Tech</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="http://www.sfchronicle.com/visionsf" class="hdn-analytics" data-hdn-analytics="visit|Biz & Tech-VisionSF|navigation|1">
+                                <div class="nav-label" data-naveid="4141">VisionSF</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/business/realestate/" class="hdn-analytics" data-hdn-analytics="visit|Biz & Tech-Real Estate|navigation|2">
+                                <div class="nav-label" data-naveid="1409">Real Estate</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/drivingthefuture/" class="hdn-analytics" data-hdn-analytics="visit|Biz & Tech-Driving the future|navigation|3">
+                                <div class="nav-label" data-naveid="4098">Driving the future</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/business/markets/" class="hdn-analytics" data-hdn-analytics="visit|Biz & Tech-Markets|navigation|4">
+                                <div class="nav-label" data-naveid="1410">Markets</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-1380" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/entertainment/" class="hdn-analytics" data-hdn-analytics="visit|A&E|navigation|8">
+                            <span class="section-link" data-naveid="1380">A&E</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/entertainment/movies-tv/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Movies & TV|navigation|1">
+                                <div class="nav-label" data-naveid="1381">Movies & TV</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/entertainment/arts-theater/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Arts & Theater|navigation|2">
+                                <div class="nav-label" data-naveid="1382">Arts & Theater</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/entertainment/music/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Music|navigation|3">
+                                <div class="nav-label" data-naveid="1383">Music</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/music-festivals/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Music Festivals Guide|navigation|4">
+                                <div class="nav-label" data-naveid="3853">Music Festivals Guide</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/entertainment/books/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Books|navigation|5">
+                                <div class="nav-label" data-naveid="1385">Books</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/badreporter/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Bad Reporter|navigation|6">
+                                <div class="nav-label" data-naveid="1647">Bad Reporter</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfgate.com/horoscope/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Horoscopes|navigation|7">
+                                <div class="nav-label" data-naveid="1388">Horoscopes</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/comics/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Comics|navigation|8">
+                                <div class="nav-label" data-naveid="1389">Comics</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfgate.com/games" class="hdn-analytics" data-hdn-analytics="visit|A&E-Games|navigation|9">
+                                <div class="nav-label" data-naveid="1392">Games</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfgate.com/cgi-bin/movies/listings/search" class="hdn-analytics" data-hdn-analytics="visit|A&E-Movie Listings|navigation|10">
+                                <div class="nav-label" data-naveid="1465">Movie Listings</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/author/leah-garchik/" class="hdn-analytics" data-hdn-analytics="visit|A&E-Leah Garchik|navigation|11">
+                                <div class="nav-label" data-naveid="3736">Leah Garchik</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-3157" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/foodandhome/" class="hdn-analytics" data-hdn-analytics="visit|Food+Home|navigation|9">
+                            <span class="section-link" data-naveid="3157">Food+Home</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/foodandhome/restaurants/" class="hdn-analytics" data-hdn-analytics="visit|Food+Home-Restaurants|navigation|1">
+                                <div class="nav-label" data-naveid="1387">Restaurants</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/foodandhome/wine/" class="hdn-analytics" data-hdn-analytics="visit|Food+Home-Wine & Beer|navigation|2">
+                                <div class="nav-label" data-naveid="1390">Wine & Beer</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/foodandhome/recipes/" class="hdn-analytics" data-hdn-analytics="visit|Food+Home-Recipes|navigation|3">
+                                <div class="nav-label" data-naveid="1391">Recipes</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/top100restaurants" class="hdn-analytics" data-hdn-analytics="visit|Food+Home-Top 100 Restaurants|navigation|4">
+                                <div class="nav-label" data-naveid="1393">Top 100 Restaurants</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/foodandhome/home-design/" class="hdn-analytics" data-hdn-analytics="visit|Food+Home-Home Design|navigation|5">
+                                <div class="nav-label" data-naveid="1373">Home Design</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-3116" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/style/" class="hdn-analytics" data-hdn-analytics="visit|Style|navigation|10">
+                            <span class="section-link" data-naveid="3116">Style</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/style/scene/" class="hdn-analytics" data-hdn-analytics="visit|Style-Scene|navigation|1">
+                                <div class="nav-label" data-naveid="3117">Scene</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/style/fashion/" class="hdn-analytics" data-hdn-analytics="visit|Style-Fashion|navigation|2">
+                                <div class="nav-label" data-naveid="3118">Fashion</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/style/weddings/" class="hdn-analytics" data-hdn-analytics="visit|Style-Weddings|navigation|3">
+                                <div class="nav-label" data-naveid="3120">Weddings</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/top-shops-2016/" class="hdn-analytics" data-hdn-analytics="visit|Style-Top Shops 2016|navigation|4">
+                                <div class="nav-label" data-naveid="4045">Top Shops 2016</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-3750" class="menu-item childless">
+                    <div class="nav-label">
+                        <a href="http://www.sfchronicle.com/lifestyle/travel/" class="hdn-analytics" data-hdn-analytics="visit|Travel|navigation|11">
+                            <span class="section-link" data-naveid="3750">Travel</span>
+                        </a>
+                    </div>
+                </li>
+                <li id="nav-menu-link-4239" class="menu-item childless">
+                    <div class="nav-label">
+                        <a href="http://www.greenstate.com/" class="hdn-analytics" data-hdn-analytics="visit|Green State|navigation|12">
+                            <span class="section-link" data-naveid="4239">Green State</span>
+                        </a>
+                    </div>
+                </li>
+                <li id="nav-menu-link-3411" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="http://www.sfchronicle.com/thetake/" class="hdn-analytics" data-hdn-analytics="visit|Photos|navigation|13">
+                            <span class="section-link" data-naveid="3411">Photos</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="http://www.sfchronicle.com/thetakepotw/" class="hdn-analytics" data-hdn-analytics="visit|Photos-Photos of the Week|navigation|1">
+                                <div class="nav-label" data-naveid="3413">Photos of the Week</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/theregulars/" class="hdn-analytics" data-hdn-analytics="visit|Photos-The Regulars|navigation|2">
+                                <div class="nav-label" data-naveid="3585">The Regulars</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-4206" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="http://www.sfchronicle.com/covers/" class="hdn-analytics" data-hdn-analytics="visit|Archives|navigation|14">
+                            <span class="section-link" data-naveid="4206">Archives</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="http://www.sfchronicle.com/covers/" class="hdn-analytics" data-hdn-analytics="visit|Archives-Chronicle Covers|navigation|1">
+                                <div class="nav-label" data-naveid="3954">Chronicle Covers</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/oursf/" class="hdn-analytics" data-hdn-analytics="visit|Archives-Our SF: Archive|navigation|2">
+                                <div class="nav-label" data-naveid="3426">Our SF: Archive</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/thetakefromthearchive/" class="hdn-analytics" data-hdn-analytics="visit|Archives-From the Archive|navigation|3">
+                                <div class="nav-label" data-naveid="3412">From the Archive</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/local/portalsofthepast/" class="hdn-analytics" data-hdn-analytics="visit|Archives-Portals of the Past|navigation|4">
+                                <div class="nav-label" data-naveid="4207">Portals of the Past</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/archive/" class="hdn-analytics" data-hdn-analytics="visit|Archives-Archives Search|navigation|5">
+                                <div class="nav-label" data-naveid="3187">Archives Search</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-3419" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="/special-reports/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth|navigation|15">
+                            <span class="section-link" data-naveid="3419">In-Depth</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="http://www.sfchronicle.com/top100restaurants" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Top 100 Restaurants|navigation|1">
+                                <div class="nav-label" data-naveid="3421">Top 100 Restaurants</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/sf-homeless/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Beyond Homelessness|navigation|2">
+                                <div class="nav-label" data-naveid="3913">Beyond Homelessness</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/oakland-fire-victims/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Oakland Fire Victims|navigation|3">
+                                <div class="nav-label" data-naveid="4200">Oakland Fire Victims</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/living-with-aids/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-AIDS Survivors|navigation|4">
+                                <div class="nav-label" data-naveid="3735">AIDS Survivors</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/sea-level-rise/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Rising sea levels|navigation|5">
+                                <div class="nav-label" data-naveid="3855">Rising sea levels</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/najee-harris/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-The Najee Chronicles|navigation|6">
+                                <div class="nav-label" data-naveid="4065">The Najee Chronicles</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/california-seafood-collapse/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Seafood's new normal|navigation|7">
+                                <div class="nav-label" data-naveid="4137">Seafood's new normal</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://projects.sfchronicle.com/2016/black-voices/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Black lives, black voices|navigation|8">
+                                <div class="nav-label" data-naveid="3939">Black lives, black voices</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/brewerymap/" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-NorCal Brewery Map|navigation|9">
+                                <div class="nav-label" data-naveid="3767">NorCal Brewery Map</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/food/article/Bar-Stars-2016-A-drink-for-everyone-9984049.php" class="hdn-analytics" data-hdn-analytics="visit|In-Depth-Bar Stars 2016|navigation|10">
+                                <div class="nav-label" data-naveid="4134">Bar Stars 2016</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-3169" class="menu-item">
+                    <div class="nav-label">
+                        <span class="arrow expand"></span>
+                        <a href="http://www.sfchronicle.com/membership/" class="hdn-analytics" data-hdn-analytics="visit|Membership|navigation|16">
+                            <span class="section-link" data-naveid="3169">Membership</span>
+                        </a>
+                    </div>
+                    <ul class="nav-submenu-list">
+                        <li>
+                            <a href="/membership/faq/" class="hdn-analytics" data-hdn-analytics="visit|Membership-About Membership|navigation|1">
+                                <div class="nav-label" data-naveid="3170">About Membership</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/membership/#offers" class="hdn-analytics" data-hdn-analytics="visit|Membership-Exclusive offers|navigation|2">
+                                <div class="nav-label" data-naveid="3172">Exclusive offers</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/subscribe/?ipid=membership" class="hdn-analytics" data-hdn-analytics="visit|Membership-Join Now|navigation|3">
+                                <div class="nav-label" data-naveid="3171">Join Now</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/e-edition/" class="hdn-analytics" data-hdn-analytics="visit|Membership-e-edition|navigation|4">
+                                <div class="nav-label" data-naveid="4199">e-edition</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/appdownload" class="hdn-analytics" data-hdn-analytics="visit|Membership-App|navigation|5">
+                                <div class="nav-label" data-naveid="4198">App</div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://www.sfchronicle.com/account" class="hdn-analytics" data-hdn-analytics="visit|Membership-Manage my account|navigation|6">
+                                <div class="nav-label" data-naveid="3173">Manage my account</div>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <li id="nav-menu-link-4117" class="menu-item childless">
+                    <div class="nav-label">
+                        <a href="https://sfchronicle.myshopify.com/" class="hdn-analytics" data-hdn-analytics="visit|Store|navigation|17">
+                            <span class="section-link" data-naveid="4117">Store</span>
+                        </a>
+                    </div>
+                </li>
+            </ul>
+        </div><!-- navMenu -->
+        <!-- e src/business/templates/hearst/common/premium_dynamic_nav.tpl -->
+    </div><!--e src/business/templates/hearst/home/premium_navigation_main.tpl -->
+    <!-- e hearst/home/navigation.tpl -->
+    <!-- e business/templates/hearst/home/HNavigation.tpl -->    <!-- end hearst/article/types/article_header.tpl -->
+
+    <!-- design/article/premium_story_page.tpl -->
+    <div id="content">
+        <div id="adAnagramDesktop">
+            <div id="AP951"><script type="text/javascript">/*<![CDATA[*/hearstPlaceAd("AP951");/*]]>*/</script></div>
+        </div>
+        <div class="article-wrap">
+            <div class="zone zone-1">
+                <div class="article-body">
+                    <!-- article/types/premium_story_header.tpl -->
+                    <div class="article-head">
+                        <h2 class="headline">Odd-jobs matchmaker Thumbtack gets big funds, joins unicorn club</h2>
+                        <!-- hearst/common/author_name.tpl -->
+                        <p class="byline">By <a href="/author/carolyn-said/">Carolyn Said</a></p>
+                        <!-- e hearst/common/author_name.tpl -->
+                        <span class="datestamp">
+                <span class="published">September 30, 2015</span>
+            <span class="updated updated">Updated: October 1, 2015 4:18pm</span>
+        </span>
+                    </div> <!-- /article-head -->
+
+                    <!-- end premium_story_header.tpl -->
+                    <div class="article-share">
+                        <!-- hearst/article/prem_article_share.tpl -->
+
+                        <div class="social-links "
+                             social-url="http%3A%2F%2Fwww.sfchronicle.com%2Fbusiness%2Farticle%2FOdd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php%3Ft%3D3fed5f9d3b%26cmpid%3D"
+                             social-hashId="" social-blurb="San%20Francisco%E2%80%99s%20Thumbtack%2C%20which%20introduces%20fix-it%20folks%2C%20caterers%2C%20yoga%20teachers%20and%20other%20professionals%20to%20people%20who%20need%20them%2C%20vaulted%20into%20the%20unicorn%20club%20this%20week%20after%20a%20%24125%20million%20funding%20round%20put%20its%20valuation%20at%20%241.3%20billion.%0A%0A%E2%80%9COur%20vision%20is%20to%20replace%20and%20reimagine%20a%20big%20chunk%20of%20the%20Yellow%20Pages%2C%E2%80%9D%20said%20CEO%20Marco%20Zappacosta%2C%20who%20co-founded%20Thumbtack%20in%202009%20after%20what%20he%20called%20a%20banal%20observation%3A%0A%0AThumbtack%20lets%20customers%20describe%20a%20job%20%E2%80%94%20anything%20from%20painting%20a%20house%20to%20walking%20a%20dog%20%E2%80%94%20with%20lots%20of%20specifics%2C%20including%20location%2C%20timing%20and%20budget.%0A%0AAfter%20the%20initial%20introduction%2C%20Thumbtack%20bows%20out%20of%20the%20relationship%2C%20although%20at%20some%20point%20it%20might%20add%20optional%20back-end%20services%20such%20as%20a%20scheduling%20platform%20and%20payment%20system%2C%20he%20said.%0A%0AHome%20improvement%2C%20Thumbtack%E2%80%99s%20biggest%20category%2C%20is%20a%20lucrative%20and%20highly%20fragmented%20market%20worth%20well%20over%20%24500%20million%20annually%20in%20the%20United%20States.%0A%0A%E2%80%9CThumbtack%20sends%20us%20exactly%20what%20customers%20are%20looking%20for%2C%E2%80%9D%20said%20Geraldine%20Chiaramonte%2C%20who%20runs%20Bay%20Area%20Candy%20Buffet%2C%20providing%20sweet%20treats%20for%20weddings%20and%20other%20occasions.%0A%0A%5B...%5D%20could%20Thumbtack%20grow%20as%20big%20as%20Google%3F%20%E2%80%9CI%20don%E2%80%99t%20want%20to%20sound%20too%20over-the-top%2C%20but%20the%20local%20services%20market%20is%20much%20larger%20than%20the%20online%20advertising%20market%2C%E2%80%9D%20Schreier%20said.%0A%0AZappacosta%20said%20its%20less-controversial%20status%20drew%20Republican%20presidential%20candidate%20Jeb%20Bush%2C%20who%20rode%20in%20an%20Uber%20to%20Thumbtack%20for%20a%20heavily%20publicized%20campaign%20stop%20in%20July%2C%20shortly%20after%20Democratic%20front-runner%20Hillary%20Rodham%20Clinton%20criticized%20the%20gig%20economy%E2%80%99s%20lack%20of%20worker%20protections."
+                             media-url="http%3A%2F%2Fww4.hdnux.com%2Fphotos%2F35%2F76%2F04%2F7856403%2F13%2FrawImage.jpg" social-title="Odd-jobs%20matchmaker%20Thumbtack%20gets%20big%20funds%2C%20joins%20unicorn%20club">
+                            <ul class="right">
+                                <li class="socialIcon print">
+                                    <a class="hdn-analytics" href="javascript:hst_print();"
+                                       data-hdn-analytics="print_article|article-6541824|article-share-premium|7">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon comments">
+                                    <a class="hdn-analytics" href="http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php#comments"
+                                       data-hdn-analytics="comments_jump|article-6541824|article-share-premium|1">
+                                        <span class="icon"></span>
+                                    </a>
+                                    <div class="viafoura">
+                                        <span class="vf-counter vf-widget" data-widget="counter" data-path="http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php"></span>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul class="left">
+                                <li class="socialIcon email" share-id="email">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="email_share|article-6541824|article-share-premium|1">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon facebook" share-id="facebook">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="facebook_share|article-6541824|article-share-premium|2">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon twitter" share-id="twitter">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="twitter_share|article-6541824|article-share-premium|3">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon pinterest" share-id="pinterest">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="pinterest_share|article-6541824|article-share-premium|4">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon reddit" share-id="reddit">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="reddit_share|article-6541824|article-share-premium|5">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon google" share-id="google">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="google_share|article-6541824|article-share-premium|6">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <!-- e hearst/article/prem_article_share.tpl -->
+                    </div>
+                    <!-- article/types/premium_story.tpl -->
+
+                    <div class="article-text">
+                        <!-- hearst/article/types/premium_story_body.tpl -->
+
+                        <a name="asset-photo-7856403"></a><div class="asset_photo asset-photo " data-config-asset-position="1"><!-- photo float --><img id="premiumsfgate-photo-7856403" src="http://ww4.hdnux.com/photos/35/76/04/7856403/13/920x1240.jpg" alt="Geraldine Orozco, founder and creative director of Bay Area Candy Buffet, arranges flowers during a &quot;dress rehearsal&quot; to prepare to cater for a client's wedding on Wednesday, pictured Tuesday, April 21, 2015, at her home in Union City, Calif. Bay Area Candy Buffet caters sweets to clients. Orozco uses Thumbtack.com, which connects consumers to home professionals. Photo: Santiago Mejia, The Chronicle" /><div class="asset_info_container asset-info-container"><!-- design/gallery/caption_redesign.tpl -->
+                        <span class="credit">
+                                            Photo: Santiago Mejia, The Chronicle
+                                    </span>
+
+                        <!-- e design/gallery/caption_redesign.tpl --><!-- hearst/article/prem_article_share.tpl -->
+
+                        <div class="social-links "
+                             social-url="http%3A%2F%2Fwww.sfchronicle.com%2Fbusiness%2Farticle%2FOdd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php%3Ft%3D3fed5f9d3b%26cmpid%3D"
+                             social-hashId="%23asset-photo-7856403" social-blurb="Geraldine%20Orozco%2C%20founder%20and%20creative%20director%20of%20Bay%20Area%20Candy%20Buffet%2C%20arranges%20flowers%20during%20a%20%26quot%3Bdress%20rehearsal%26quot%3B%20to%20prepare%20to%20cater%20for%20a%20client%27s%20wedding%20on%20Wednesday%2C%20pictured%20Tuesday%2C%20April%2021%2C%202015%2C%20at%20her%20home%20in%20Union%20City%2C%20Calif.%20Bay%20Area%20Candy%20Buffet%20caters%20sweets%20to%20clients.%20Orozco%20uses%20Thumbtack.com%2C%20which%20connects%20consumers%20to%20home%20professionals."
+                             media-url="http%3A%2F%2Fww4.hdnux.com%2Fphotos%2F35%2F76%2F04%2F7856403%2F13%2F960x960.jpg" social-title="Odd-jobs%20matchmaker%20Thumbtack%20gets%20big%20funds%2C%20joins%20unicorn%20club">
+                            <ul class="right">
+                                <li class="socialIcon print">
+                                    <a class="hdn-analytics" href="javascript:hst_print();"
+                                       data-hdn-analytics="print_article_embed|photo-7856403|article-6541824|7">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon comments">
+                                    <a class="hdn-analytics" href="#comments"
+                                       data-hdn-analytics="comments_jump_embed|photo-7856403|article-6541824|1">
+                                        <span class="icon"></span>
+                                    </a>
+                                    <div class="viafoura">
+                                        <span class="vf-counter vf-widget" data-widget="counter"></span>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul class="left hidden">
+                                <li class="socialIcon email" share-id="email">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="email_share_embed|photo-7856403|article-6541824|1">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon facebook" share-id="facebook">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="facebook_share_embed|photo-7856403|article-6541824|2">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon twitter" share-id="twitter">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="twitter_share_embed|photo-7856403|article-6541824|3">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon pinterest" share-id="pinterest">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="pinterest_share_embed|photo-7856403|article-6541824|4">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon reddit" share-id="reddit">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="reddit_share_embed|photo-7856403|article-6541824|5">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                                <li class="socialIcon google" share-id="google">
+                                    <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="google_share_embed|photo-7856403|article-6541824|6">
+                                        <span class="icon"></span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <!-- e hearst/article/prem_article_share.tpl --><div class="share-toggle"><span class="icon"></span></div></div><!-- /asset_info_container --><!-- design/gallery/caption_redesign.tpl -->
+                        <div class="caption">
+                            Geraldine Orozco, founder and creative director of Bay Area Candy Buffet, arranges flowers during a "dress rehearsal" to prepare to cater for a client's wedding on Wednesday, pictured Tuesday, April 21, 2015, at her home in Union City, Calif. Bay Area Candy Buffet caters sweets to clients. Orozco uses Thumbtack.com, which connects consumers to home professionals.
+
+                        </div>
+                        <div class="caption-truncated" style="display:none;">Geraldine Orozco, founder and creative director of Bay Area Candy...</div>
+                        <!-- e design/gallery/caption_redesign.tpl --></div><!-- /photo float -->    <!-- hmb:ap300 ap300 ad -->
+
+                        <script type="text/javascript">
+            if (window.innerWidth > 768) {
+                document.write('<div id="A300Desktop" class="ad-inner"><div id="AP300" class="ad_deferrable"><scr' + 'ipt type="text/javascript">/*<![CDATA[*/ hearstPlaceAd("AP300"); /*]]>*/ </scr' + 'ipt></div></div>');
+            }
+        </script>
+
+                        <p>San Francisco&rsquo;s <a href="http://thumbtack.com">Thumbtack</a>, which introduces fix-it folks, caterers, yoga teachers and other professionals to people who need them, vaulted into the unicorn club this week after a $125 million funding round put its valuation at $1.3 billion.</p>
+                        <div class="sync-inline-overlay"><p>&ldquo;Our vision is to replace and reimagine a big chunk of the Yellow Pages,&rdquo; said CEO Marco Zappacosta, who co-founded Thumbtack in 2009 after what he called a &ldquo;banal observation: Why is it so damn hard to find a plumber?&rdquo; </p>
+                            <div class="asset_relatedlinks"><!-- relatedlinks float --><!-- hearst/article/premium_relatedStories.tpl -->
+                                <div class="article-related">
+                                    <h4 class="in-title">Look! Unicorns!</h4>
+                                    <ul class="rel-links">
+                                        <li class="rel-item ">
+                                            <div class="rel-thumb">
+                                                <!-- common/display_image.tpl -->
+                                                <a class="without_u  hdn-analytics"
+                                                   href="/business/article/Mobile-startups-worth-800-billion-combined-a-6499515.php"
+                                                   data-hdn-analytics="related_stories|article-6499515|article-6541824|1">
+                                                    <img src="http://ww4.hdnux.com/photos/35/46/03/7758059/9/premium_landscape.jpg"
+                                                         alt="Bobby Murphy, 24, left, and Evan Spiegel, 22, co-creators of Snapchat, are seen through a window of the company's offices on Ocean Front Walk on May 6, 2013 in Venice, Calif. In 2013, co-founder Reggie Brown sued his former colleages and venture capitalists, alleging breach of contract. (Genaro Molina/Los Angeles Times/TNS)" border="0" />
+                                                </a>
+                                                <!-- e display_image.tpl -->
+                                            </div>
+                                            <a class="hdn-analytics" href="/business/article/Mobile-startups-worth-800-billion-combined-a-6499515.php"
+                                               data-hdn-analytics="related_stories|article-6499515|article-6541824|1">Mobile startups worth $800B combined a sign of bubble</a>
+                                        </li>
+                                        <li class="rel-item ">
+                                            <div class="rel-thumb">
+                                                <!-- common/display_image.tpl -->
+                                                <a class="without_u  hdn-analytics"
+                                                   href="/business/article/How-S-F-companies-turn-stock-options-into-cash-6485919.php"
+                                                   data-hdn-analytics="related_stories|article-6485919|article-6541824|2">
+                                                    <img src="http://ww4.hdnux.com/photos/40/47/47/8550907/11/premium_landscape.jpg"
+                                                         alt="Jason Zhu, Kabam's head of UA partnerships, works at his desk, Friday, Aug. 28, 2015, in San Francisco, Calif." border="0" />
+                                                </a>
+                                                <!-- e display_image.tpl -->
+                                            </div>
+                                            <a class="hdn-analytics" href="/business/article/How-S-F-companies-turn-stock-options-into-cash-6485919.php"
+                                               data-hdn-analytics="related_stories|article-6485919|article-6541824|2">How S.F. firms turn stock options into cash — without IPO</a>
+                                        </li>
+                                        <li class="rel-item ">
+                                            <div class="rel-thumb">
+                                                <!-- common/display_image.tpl -->
+                                                <a class="without_u  hdn-analytics"
+                                                   href="/business/article/Looking-beyond-software-venture-capitalists-6470141.php"
+                                                   data-hdn-analytics="related_stories|article-6470141|article-6541824|3">
+                                                    <img src="http://ww3.hdnux.com/photos/40/44/60/8539150/17/premium_landscape.jpg"
+                                                         alt="Yelena Budouskaya, a senior scientist, puts DNA into tubes for amplification at uBiome, a biotech company in San Francisco, California, on Wednesday, Aug. 26, 2015. uBiome, which sequences people's microbiomes received a large amount of Venture Capital funding after getting its start through crowd funding." border="0" />
+                                                </a>
+                                                <!-- e display_image.tpl -->
+                                            </div>
+                                            <a class="hdn-analytics" href="/business/article/Looking-beyond-software-venture-capitalists-6470141.php"
+                                               data-hdn-analytics="related_stories|article-6470141|article-6541824|3">Looking beyond software, VCs turning to biotech</a>
+                                        </li>
+                                        <li class="rel-item last">
+                                            <div class="rel-thumb">
+                                                <!-- common/display_image.tpl -->
+                                                <a class="without_u  hdn-analytics"
+                                                   href="/business/article/Why-no-one-can-reliably-predict-a-tech-bubble-6369318.php"
+                                                   data-hdn-analytics="related_stories|article-6369318|article-6541824|4">
+                                                    <img src="http://ww3.hdnux.com/photos/36/55/25/8050010/5/premium_landscape.jpg"
+                                                         alt="Trader Peter Tuchman, left, and specialist Jay Woods works the post that handles Time Warner Cable on the floor of the New York Stock Exchange, Tuesday, May 26, 2015.  Charter Communications is buying Time Warner Cable for $55.33 billion, creating another U.S. TV and Internet giant.v (AP Photo/Richard Drew)" border="0" />
+                                                </a>
+                                                <!-- e display_image.tpl -->
+                                            </div>
+                                            <a class="hdn-analytics" href="/business/article/Why-no-one-can-reliably-predict-a-tech-bubble-6369318.php"
+                                               data-hdn-analytics="related_stories|article-6369318|article-6541824|4">Why no one can reliably predict a tech bubble</a>
+                                        </li>
+                                    </ul>
+                                </div>
+
+                                <!-- end hearst/article/premium_relatedStories.tpl --></div><!-- /relatedlinks float --><p>Thumbtack lets customers describe a job &mdash; anything from painting a house to walking a dog &mdash; with lots of specifics, including location, timing and budget. It sends those leads to service providers, who pay from $3 to $20 for the customer&rsquo;s contact information so they can follow up with a quote. Each project can receive up to five quotes. &ldquo;We&rsquo;re more like a dating app than a traditional e-commerce site,&rdquo; Zappacosta said.</p>
+                            <!-- hmb:ap300 ap300 ad -->
+
+                            <script type="text/javascript">
+            if (window.innerWidth <= 768) {
+			    document.write('<div id="A300Mobile" class="ad-inner"><div id="AP300" class="ad_deferrable"><scr' + 'ipt type="text/javascript">/*<![CDATA[*/ hearstPlaceAd("AP300"); /*]]>*/ </scr' + 'ipt></div></div>');
+            }
+        </script>
+
+                            <!-- fixed-asset perfectPixelWide --><!-- hearst/item/standalone.tpl -->
+                            <div class="hdnce-e hdnce-item-47193"><!-- mid:freeform.47193 -->
+                                <div class="fixed-asset perfectPixelWide ndn_embed" id="ndn-video-player-1" data-config-distributor-id="45981" data-config-width="100%" data-config-height="9/16w"></div>
+                            </div><!-- / hdnce-e --><!-- e fixed-asset perfectPixelWide --><p>After the initial introduction, Thumbtack bows out of the relationship, although at some point it might add optional back-end services such as a scheduling platform and payment system, he said. </p>
+                            <p>The site facilitates more than 5 million projects a year, averaging about $500 each. Home improvement, Thumbtack&rsquo;s biggest category, is a lucrative and highly fragmented market worth well over $500 million annually in the United States. It lists 200,000 professionals in 1,500 categories, including electricians, plumbers, painters, personal trainers, interior designers, gardeners, DJs, tutors, coaches, florists and makeup artists. Zappacosta once offered Italian cooking lessons and catering via the site, which he said was invaluable in learning a service pro&rsquo;s perspective.</p>
+                            <p>&ldquo;Thumbtack sends us exactly what customers are looking for,&rdquo; said Geraldine Chiaramonte, who runs <a href="http://bayareacandybuffet.com/">Bay Area Candy Buffet</a>, providing sweet treats for weddings and other occasions. Once she sees the requests, she decides whether to pay $3 per lead to follow up with a proposal. Up to a third of her business now comes from Thumbtack, after three years on the site. </p>
+                            <p>A good analogy for what Thumbtack does is the Internet itself, said Bryan Schreier, a partner at Sequoia, which invested in Thumbtack&rsquo;s current round and three prior ones. &ldquo;There was a ton of information online, but it took Google to actually make that information useful and make it easier to connect consumers with what they were looking for,&rdquo; he said. &ldquo;This is a similar approach to solving a very big problem.&rdquo;</p>
+                            <a name="asset-photo-7856401"></a><div class="asset_photo asset-photo " data-config-asset-position="6"><!-- photo float --><img id="premiumsfgate-photo-7856401" src="http://ww2.hdnux.com/photos/35/76/04/7856401/15/920x1240.jpg" alt="Gluten-free sour watermelons from the Bay Area Candy Buffet, Tuesday, April 21, 2015, in Union City, Calif. Bay Area Candy Buffet caters sweets to clients. Photo: Santiago Mejia, The Chronicle" /><div class="asset_info_container asset-info-container"><!-- design/gallery/caption_redesign.tpl -->
+                                <span class="credit">
+                                            Photo: Santiago Mejia, The Chronicle
+                                    </span>
+
+                                <!-- e design/gallery/caption_redesign.tpl --><!-- hearst/article/prem_article_share.tpl -->
+
+                                <div class="social-links "
+                                     social-url="http%3A%2F%2Fwww.sfchronicle.com%2Fbusiness%2Farticle%2FOdd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php%3Ft%3D3fed5f9d3b%26cmpid%3D"
+                                     social-hashId="%23asset-photo-7856401" social-blurb="Gluten-free%20sour%20watermelons%20from%20the%20Bay%20Area%20Candy%20Buffet%2C%20Tuesday%2C%20April%2021%2C%202015%2C%20in%20Union%20City%2C%20Calif.%20Bay%20Area%20Candy%20Buffet%20caters%20sweets%20to%20clients."
+                                     media-url="http%3A%2F%2Fww2.hdnux.com%2Fphotos%2F35%2F76%2F04%2F7856401%2F15%2F960x960.jpg" social-title="Odd-jobs%20matchmaker%20Thumbtack%20gets%20big%20funds%2C%20joins%20unicorn%20club">
+                                    <ul class="right">
+                                        <li class="socialIcon print">
+                                            <a class="hdn-analytics" href="javascript:hst_print();"
+                                               data-hdn-analytics="print_article_embed|photo-7856401|article-6541824|7">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon comments">
+                                            <a class="hdn-analytics" href="#comments"
+                                               data-hdn-analytics="comments_jump_embed|photo-7856401|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                            <div class="viafoura">
+                                                <span class="vf-counter vf-widget" data-widget="counter"></span>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <ul class="left hidden">
+                                        <li class="socialIcon email" share-id="email">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="email_share_embed|photo-7856401|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon facebook" share-id="facebook">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="facebook_share_embed|photo-7856401|article-6541824|2">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon twitter" share-id="twitter">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="twitter_share_embed|photo-7856401|article-6541824|3">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon pinterest" share-id="pinterest">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="pinterest_share_embed|photo-7856401|article-6541824|4">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon reddit" share-id="reddit">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="reddit_share_embed|photo-7856401|article-6541824|5">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon google" share-id="google">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="google_share_embed|photo-7856401|article-6541824|6">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <!-- e hearst/article/prem_article_share.tpl --><div class="share-toggle"><span class="icon"></span></div></div><!-- /asset_info_container --><!-- design/gallery/caption_redesign.tpl -->
+                                <div class="caption">
+                                    Gluten-free sour watermelons from the Bay Area Candy Buffet, Tuesday, April 21, 2015, in Union City, Calif. Bay Area Candy Buffet caters sweets to clients.
+
+                                </div>
+                                <div class="caption-truncated" style="display:none;">Gluten-free sour watermelons from the Bay Area Candy Buffet,...</div>
+                                <!-- e design/gallery/caption_redesign.tpl --></div><!-- /photo float --><p>So could Thumbtack grow as big as Google? &ldquo;I don&rsquo;t want to sound too over-the-top, but the local services market is much larger than the online advertising market,&rdquo; Schreier said. &ldquo;Thumbtack is a very large business already, when the reality is that they are tapping less than 1 percent of the available market today.&rdquo;</p>
+                            <p>That market&rsquo;s gargantuan size has lured behemoths, with both Amazon and Google experimenting with their own home-repairs offerings. Google Capital is also an investor in Thumbtack, having led a $100 million round last year, as well as participating in the current round. </p>
+                            <p>The latest funding brings Thumbtack&rsquo;s total backing to $273.2 million. It was led by Scottish investment firm Baillie Gifford with several existing investors participating. Zappacosta said the money will go toward improving the product and marketing the brand. Thumbtack has 134 employees in San Francisco and 240 in Salt Lake City, where its customer service is based. </p>
+                            <a name="asset-photo-7856394"></a><div class="asset_photo asset-photo " data-config-asset-position="7"><!-- photo float --><img id="premiumsfgate-photo-7856394" src="http://ww3.hdnux.com/photos/35/76/04/7856394/15/920x1240.jpg" alt="Geraldine Orozco, founder and creative director of Bay Area Candy Buffet, went through a &quot;dress rehearsal&quot; to prepare to cater for a client's wedding on Wednesday, pictured Tuesday, April 21, 2015, at her home in Union City, Calif. Bay Area Candy Buffet caters sweets to clients. Orozco uses Thumbtack.com, which connects consumers to home professionals. Photo: Santiago Mejia, The Chronicle" /><div class="asset_info_container asset-info-container"><!-- design/gallery/caption_redesign.tpl -->
+                                <span class="credit">
+                                            Photo: Santiago Mejia, The Chronicle
+                                    </span>
+
+                                <!-- e design/gallery/caption_redesign.tpl --><!-- hearst/article/prem_article_share.tpl -->
+
+                                <div class="social-links "
+                                     social-url="http%3A%2F%2Fwww.sfchronicle.com%2Fbusiness%2Farticle%2FOdd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php%3Ft%3D3fed5f9d3b%26cmpid%3D"
+                                     social-hashId="%23asset-photo-7856394" social-blurb="Geraldine%20Orozco%2C%20founder%20and%20creative%20director%20of%20Bay%20Area%20Candy%20Buffet%2C%20went%20through%20a%20%26quot%3Bdress%20rehearsal%26quot%3B%20to%20prepare%20to%20cater%20for%20a%20client%27s%20wedding%20on%20Wednesday%2C%20pictured%20Tuesday%2C%20April%2021%2C%202015%2C%20at%20her%20home%20in%20Union%20City%2C%20Calif.%20Bay%20Area%20Candy%20Buffet%20caters%20sweets%20to%20clients.%20Orozco%20uses%20Thumbtack.com%2C%20which%20connects%20consumers%20to%20home%20professionals."
+                                     media-url="http%3A%2F%2Fww3.hdnux.com%2Fphotos%2F35%2F76%2F04%2F7856394%2F15%2F960x960.jpg" social-title="Odd-jobs%20matchmaker%20Thumbtack%20gets%20big%20funds%2C%20joins%20unicorn%20club">
+                                    <ul class="right">
+                                        <li class="socialIcon print">
+                                            <a class="hdn-analytics" href="javascript:hst_print();"
+                                               data-hdn-analytics="print_article_embed|photo-7856394|article-6541824|7">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon comments">
+                                            <a class="hdn-analytics" href="#comments"
+                                               data-hdn-analytics="comments_jump_embed|photo-7856394|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                            <div class="viafoura">
+                                                <span class="vf-counter vf-widget" data-widget="counter"></span>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <ul class="left hidden">
+                                        <li class="socialIcon email" share-id="email">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="email_share_embed|photo-7856394|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon facebook" share-id="facebook">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="facebook_share_embed|photo-7856394|article-6541824|2">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon twitter" share-id="twitter">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="twitter_share_embed|photo-7856394|article-6541824|3">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon pinterest" share-id="pinterest">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="pinterest_share_embed|photo-7856394|article-6541824|4">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon reddit" share-id="reddit">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="reddit_share_embed|photo-7856394|article-6541824|5">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon google" share-id="google">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="google_share_embed|photo-7856394|article-6541824|6">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <!-- e hearst/article/prem_article_share.tpl --><div class="share-toggle"><span class="icon"></span></div></div><!-- /asset_info_container --><!-- design/gallery/caption_redesign.tpl -->
+                                <div class="caption">
+                                    Geraldine Orozco, founder and creative director of Bay Area Candy Buffet, went through a "dress rehearsal" to prepare to cater for a client's wedding on Wednesday, pictured Tuesday, April 21, 2015, at her home in Union City, Calif. Bay Area Candy Buffet caters sweets to clients. Orozco uses Thumbtack.com, which connects consumers to home professionals.
+
+                                </div>
+                                <div class="caption-truncated" style="display:none;">Geraldine Orozco, founder and creative director of Bay Area Candy...</div>
+                                <!-- e design/gallery/caption_redesign.tpl --></div><!-- /photo float --><p>Some rivals such as TaskRabbit act as middlemen, arranging each service call in exchange for a cut. That model &mdash; like that of Uber, Lyft, Postmates and other gig economy services &mdash; has stirred up huge controversy about whether the independent-contractor workers should be reclassified as employees. That&rsquo;s not an issue for Thumbtack, since it operates as a referral service.</p>
+                            <p>Zappacosta said its less-controversial status drew Republican presidential candidate Jeb Bush, who rode in an Uber to Thumbtack for a heavily publicized campaign stop in July, shortly after Democratic front-runner Hillary Rodham Clinton criticized the gig economy&rsquo;s lack of worker protections. </p>
+                            <p>&ldquo;We are unambiguously a force to empower business owners, not try to replace them,&rdquo; Zappacosta said. &ldquo;Jeb was trying to align with pro-business sentiment.&rdquo;</p>
+                            <em>
+                                <p>Carolyn Said is a San Francisco Chronicle staff writer. E-mail: <a href="mailto:csaid@sfchronicle.com">csaid@sfchronicle.com</a> Twitter: @csaid</p>
+                            </em>
+                            <p></p>
+                            <a name="asset-photo-7856393"></a><div class="asset_photo asset-photo " data-config-asset-position="8"><!-- photo float --><img id="premiumsfgate-photo-7856393" src="http://ww2.hdnux.com/photos/35/76/04/7856393/11/920x1240.jpg" alt="Petit fours from the Bay Area Candy Buffet, Tuesday, April 21, 2015, in Union City, Calif. The company caters sweets to clients. Photo: Santiago Mejia, The Chronicle" /><div class="asset_info_container asset-info-container"><!-- design/gallery/caption_redesign.tpl -->
+                                <span class="credit">
+                                            Photo: Santiago Mejia, The Chronicle
+                                    </span>
+
+                                <!-- e design/gallery/caption_redesign.tpl --><!-- hearst/article/prem_article_share.tpl -->
+
+                                <div class="social-links "
+                                     social-url="http%3A%2F%2Fwww.sfchronicle.com%2Fbusiness%2Farticle%2FOdd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php%3Ft%3D3fed5f9d3b%26cmpid%3D"
+                                     social-hashId="%23asset-photo-7856393" social-blurb="Petit%20fours%20from%20the%20Bay%20Area%20Candy%20Buffet%2C%20Tuesday%2C%20April%2021%2C%202015%2C%20in%20Union%20City%2C%20Calif.%20The%20company%20caters%20sweets%20to%20clients."
+                                     media-url="http%3A%2F%2Fww2.hdnux.com%2Fphotos%2F35%2F76%2F04%2F7856393%2F11%2F960x960.jpg" social-title="Odd-jobs%20matchmaker%20Thumbtack%20gets%20big%20funds%2C%20joins%20unicorn%20club">
+                                    <ul class="right">
+                                        <li class="socialIcon print">
+                                            <a class="hdn-analytics" href="javascript:hst_print();"
+                                               data-hdn-analytics="print_article_embed|photo-7856393|article-6541824|7">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon comments">
+                                            <a class="hdn-analytics" href="#comments"
+                                               data-hdn-analytics="comments_jump_embed|photo-7856393|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                            <div class="viafoura">
+                                                <span class="vf-counter vf-widget" data-widget="counter"></span>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <ul class="left hidden">
+                                        <li class="socialIcon email" share-id="email">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="email_share_embed|photo-7856393|article-6541824|1">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon facebook" share-id="facebook">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="facebook_share_embed|photo-7856393|article-6541824|2">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon twitter" share-id="twitter">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="twitter_share_embed|photo-7856393|article-6541824|3">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon pinterest" share-id="pinterest">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="pinterest_share_embed|photo-7856393|article-6541824|4">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon reddit" share-id="reddit">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="reddit_share_embed|photo-7856393|article-6541824|5">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                        <li class="socialIcon google" share-id="google">
+                                            <a class="hdn-analytics" href="" onclick="return false;" data-hdn-analytics="google_share_embed|photo-7856393|article-6541824|6">
+                                                <span class="icon"></span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <!-- e hearst/article/prem_article_share.tpl --><div class="share-toggle"><span class="icon"></span></div></div><!-- /asset_info_container --><!-- design/gallery/caption_redesign.tpl -->
+                                <div class="caption">
+                                    Petit fours from the Bay Area Candy Buffet, Tuesday, April 21, 2015, in Union City, Calif. The company caters sweets to clients.
+
+                                </div>
+                                <div class="caption-truncated" style="display:none;">Petit fours from the Bay Area Candy Buffet, Tuesday, April 21,...</div>
+                                <!-- e design/gallery/caption_redesign.tpl --></div><!-- /photo float --></div><!-- /sync-inline-overlay -->
+
+                        <!-- e premium_hearst/article/types/premium_story_body.tpl -->
+                    </div>
+                    <!-- e /hearst/article/types/premium_story.tpl -->
+
+                    <!-- hearst/article/premium_author_module.tpl -->
+                    <div class="author-wrap">
+                        <div class="authorinfo noborder last">
+                            <img src="http://ww3.hdnux.com/photos/42/17/45/8976742/3/premium_author_module.jpg" alt="Carolyn Said" />
+                            <h2 class="name">
+                                <a href="/author/carolyn-said/">Carolyn Said</a>
+                            </h2>
+                            <p class="title">Business Reporter</p>
+                        </div>
+                    </div>
+                    <!-- hearst/article/premium_author_module.tpl -->
+                </div>
+            </div>
+            <!-- END Article Body-->
+            <div class="zone zone-1" style="clear:both">
+            </div>
+            <!-- /zone 1-->
+            <div class="zone zone-3">
+                <div class="article-comments">
+                    <!-- comments get dynamically inserted here -->
+
+                    <div id="comments" class="hdn-comments">
+                        <!-- ux/premiumsfgate/home/modal_signin_form.tpl -->
+
+                        <script>
+    if (typeof (treg.html) !== "undefined") {
+        HDN.getAtCookie();
+        document.write('<div class="treg-gya-commenting-bar"></div>');
+    }
+</script>
+
+                        <!-- e ux/premiumsfgate/home/modal_signin_form.tpl -->
+                        <div id="hdn-vf-comments"></div>
+                    </div>                                                                        </div>
+            </div>
+        </div>
+        <div class="zone zone-5">
+            <!-- src/business/widgets/hearst/collection/widget.tpl -->
+
+            <div class="hide-rss-link hdnce-e hdnce-collection-20952-premium_article_featured_articles"><!-- collections/premium_article_featured_articles.tpl -->
+                <!-- collection.premium_article_featured_articles.20952 -->
+                <div class="collection article-sections">
+                    <div class="column-outer-wrap">
+                        <div class="column-wrap ">
+                            <div class="column odd firstcolumn">
+                                <div class="header">
+                                    <h4 class="kicker-link"><a href="">Matier & Ross</a></h4>
+                                </div>
+                                <!-- common/display_image.tpl -->
+                                <a class="without_u  "
+                                   href="/bayarea/matier-ross/article/With-Warriors-in-Finals-Oakland-spurns-plan-to-11193683.php"
+                                >
+                                    <img src="http://ww4.hdnux.com/photos/61/52/66/13020547/3/premium_article_featured_articles.jpg"
+                                         alt="Mezzanine suite 14 during Game 1 of the NBA Finals between the Golden State Warriors and Cleveland Cavaliers on Thursday, June 1, 2017, in Oakland, Calif. The Oakland City Council considered selling its luxury box at Oracle Arena to the Warriors for $200,000 to help generate funds for the cash-strapped city. In the end members balked at the deal. Some council members allegedly didn't want to part with the valuable seats, especially during the Warriors playoffs." border="0" />
+                                </a>
+                                <!-- e display_image.tpl -->
+                                <h2 class="headline"><a   href="/bayarea/matier-ross/article/With-Warriors-in-Finals-Oakland-spurns-plan-to-11193683.php">With Warriors in Finals, Oakland spurns plan to sell luxury box</a></h2>
+                            </div>
+                            <div class="column even ">
+                                <div class="header">
+                                    <h4 class="kicker-link"><a   href="/us-world/">US & World</a></h4>
+                                </div>
+                                <!-- common/display_image.tpl -->
+                                <a class="without_u  "
+                                   href="/nation/article/Clean-energy-too-big-to-be-shut-down-by-Trump-11194036.php"
+                                >
+                                    <img src="http://ww1.hdnux.com/photos/61/52/21/13018196/3/premium_article_featured_articles.jpg"
+                                         alt="In this April 30, 2008 file photo, American flags are seen near the Shell refinery, in Martinez, Calif. On Weds., Nov. 14, 2012, California�s largest greenhouse gas emitters will for the first time begin buying permits in a landmark &quot;cap-and-trade&quot; system meant to control emissions of heat-trapping gases and spur investment in clean technologies. The program is a key part of California�s 2006 climate-change law, AB32, a suite of regulations that dictate standards for cleaner-burning fuels, more efficient automobiles and increased use of renewable energy. (AP Photo/Ben Margot, File)" border="0" />
+                                </a>
+                                <!-- e display_image.tpl -->
+                                <h2 class="headline"><a   href="/nation/article/Clean-energy-too-big-to-be-shut-down-by-Trump-11194036.php">Clean energy too big to be shut down by Trump</a></h2>
+                            </div>
+                        </div>
+                        <div class="column-wrap column-wrap-last">
+                            <div class="column odd ">
+                                <div class="header">
+                                    <h4 class="kicker-link"><a   href="/entertainment/arts-theater/">Arts & Theater</a></h4>
+                                </div>
+                                <!-- common/display_image.tpl -->
+                                <a class="without_u  "
+                                   href="/performance/article/Guide-to-Clusterfest-Comics-chaos-and-a-big-11170524.php"
+                                >
+                                    <img src="http://ww3.hdnux.com/photos/61/40/51/12978774/3/premium_article_featured_articles.jpg"
+                                         alt="" border="0" />
+                                </a>
+                                <!-- e display_image.tpl -->
+                                <h2 class="headline"><a   href="/performance/article/Guide-to-Clusterfest-Comics-chaos-and-a-big-11170524.php">Guide to Clusterfest: Comics, chaos and a big salad</a></h2>
+                            </div>
+                            <div class="column even lastcolumn">
+                                <div class="header">
+                                    <h4 class="kicker-link"><a href="http://projects.sfchronicle.com/2017/top-100-restaurants/">Top 100 Restaurants</a></h4>
+                                </div>
+                                <!-- common/display_image.tpl -->
+                                <a class="without_u hdnce-e hdnce-link-33868 "
+                                   href="http://projects.sfchronicle.com/2017/top-100-restaurants/"
+                                >
+                                    <img src="http://ww1.hdnux.com/photos/60/64/73/12799712/4/premium_article_featured_articles.jpg"
+                                         alt="" border="0" />
+                                </a>
+                                <!-- e display_image.tpl -->
+                                <h2 class="headline"><a class="hdnce-e hdnce-link-33868"  href="http://projects.sfchronicle.com/2017/top-100-restaurants/">Top 100 Restaurants 2017: Savor Bay Area's best</a></h2>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- end premium_article_featured_articles.tpl -->
+            </div><!-- e src/business/widgets/hearst/collection/widget.tpl -->
+        </div><!-- /zone-5 -->
+        <!-- END Section Highlights Collection -->
+    </div>
+    <div class="zone zonePremiumF">
+        <!-- src/business/widgets/hearst/collection/widget.tpl -->
+
+        <div class="hide-rss-link hdnce-e hdnce-collection-21167-premium_article_carousel"><!-- src/business/templates/hearst/collections/premium_article_carousel.tpl -->
+
+
+
+
+            <script type="text/javascript">
+    // Article array
+    var storyList = [
+            
+                
+                                                                    {
+            "headline":"Best home video and TV gifts for Father's Day",
+            "imageUrl":"http://ww3.hdnux.com/photos/61/52/55/13020006/5/premium_article_carousel.jpg",
+            "articleUrl":"/technology/cnet/article/Best-home-video-and-TV-gifts-for-Father-s-Day-11192733.php",
+            "timeStamp" : ""
+    },
+            
+                
+                                                                                                    {
+            "headline":"Good Walk Scores have SF buyers, renters running to homes",
+            "imageUrl":"http://ww3.hdnux.com/photos/61/52/03/13017306/7/premium_article_carousel.jpg",
+            "articleUrl":"/business/networth/article/Good-Walk-Scores-have-SF-buyers-renters-running-11192601.php",
+            "timeStamp" : ""
+    },
+            
+                
+                                                                    {
+            "headline":"Airbnb hosts more likely to reject the disabled, a study finds",
+            "imageUrl":"http://ww4.hdnux.com/photos/60/16/64/12643599/7/premium_article_carousel.jpg",
+            "articleUrl":"/business/article/Airbnb-hosts-more-likely-to-reject-the-disabled-11192712.php",
+            "timeStamp" : ""
+    },
+            
+                
+                                                                                                    {
+            "headline":"BART loops in riders with hearing loss",
+            "imageUrl":"http://ww3.hdnux.com/photos/61/46/17/13001666/5/premium_article_carousel.jpg",
+            "articleUrl":"/business/article/BART-loops-in-riders-with-hearing-loss-11192230.php",
+            "timeStamp" : ""
+    },
+            
+                
+                                                                                                    {
+            "headline":"ICYMI: McDonald's delivers; Dunkin' complains; a 'covfefe' fail",
+            "imageUrl":"",
+            "articleUrl":"/business/article/ICYMI-McDonald-s-delivers-Dunkin-11192635.php",
+            "timeStamp" : ""
+    },
+            
+                
+                                                                                                    {
+            "headline":"Move hat making into a US factory? Easier said than done",
+            "imageUrl":"http://ww1.hdnux.com/photos/61/51/01/13013104/3/premium_article_carousel.jpg",
+            "articleUrl":"/business/article/Move-hat-making-into-a-US-factory-Easier-said-11192623.php",
+            "timeStamp" : ""
+    },
+    ];
+</script>
+
+            <div id="fixedCarousel" class="carousel-wrap ">
+                <div class="navLink prevLink">
+                    <a id="showPrev"></a>
+                </div>
+                <div class="carousel-list">
+                    <div id="carouselItem1" class="carousel-item">
+                        <div class="carousel-thumb"><a href=""></a> </div>
+                        <h3><span class="timestamp"></span><a href=""></a></h3>
+                    </div>
+                    <div id="carouselItem2" class="carousel-item">
+                        <div class="carousel-thumb"><a href=""></a> </div>
+                        <h3><span class="timestamp"></span><a href=""></a></h3>
+                    </div>
+                    <div id="carouselItem3" class="carousel-item">
+                        <div class="carousel-thumb"><a href=""></a> </div>
+                        <h3><span class="timestamp"></span><a href=""></a></h3>
+                    </div>
+                </div>
+                <div class="navLink nextLink">
+                    <a id="showNext"></a>
+                </div>
+            </div>
+
+            <div id="carouselListView" class="list-view-wrap">
+                <div class="list-view-eyebrow">
+                    <h4><a href="">Biz & Tech </a></h4>
+                </div>
+                <div id="listView1" class="list-view">
+                    <div id="listItem0" class="list-view-item"></div>
+                </div>
+                <div class="list-view-footer">
+                    <a id="loadMore"><span class="load-icon"></span>Load more in Section</a>
+                </div>
+            </div>
+            <!-- e src/business/templates/hearst/collections/premium_article_carousel.tpl -->
+        </div><!-- e src/business/widgets/hearst/collection/widget.tpl -->        </div><!-- /zonePremiumF -->
+    <!-- e design/article/premium_story_page.tpl --><!-- src/business/templates/hearst/common/footer.tpl -->
+
+    <!-- hearst/common/premium_site_footer.tpl -->
+    <!-- templates/hearst/home/viafouraFooterJS.tpl -->
+    <script>
+                
+    (function (v, s) {
+        v.type = 'text/javascript';
+        v.async = !0;
+        v.src = location.protocol !== 'https:' ? '//cdn.viafoura.net/vf.js' : '//api.viafoura.com/app/js/vf.js';
+        s.parentNode.insertBefore(v, s)
+    }(document.createElement('script'), document.getElementsByTagName('script')[0]));
+    
+        
+    $(document).ready(function () {
+    
+        
+        if ($('#hdn-vf-comments').length) {HDN.authOnReady('premium',false)}
+    
+        
+        var vfDomains = {};
+        $('body').find('div.viafoura span.vf-counter[data-path^="http://"]').each(function () {
+            var matches = $(this).attr('data-path').match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
+            var domain = matches && matches[1];
+            if (!!domain) {
+                vfDomains[domain.replace(/^m\./, 'www.')] = 1;
+            }
+        });
+        for (d in vfDomains) {
+            HDN.getVfCommentCount(undefined,d,1);
+        }
+    });
+    
+</script>
+    <!-- e templates/hearst/home/viafouraFooterJS.tpl -->
+
+
+    <!-- hearst/item/standalone.tpl -->
+    <div class="hdnce-e hdnce-item-14555"><!-- mid:freeform.14555 -->
+        <div class="hc_sitefooter">
+            <div class="lock1200">
+                <div class="hcsf_header">
+                    <a href="http://www.sfchronicle.com"><img src="/img/modules/sitefooter/footer_logo.png"></a>
+                    <div class="toplink"><a href="#container"><span class="topLinkText">Top</span></a></div>
+                </div>
+                <ul class="hcsf_links">
+                    <li class="hcsf_about">
+                        <h3>About</h3>
+                        <ul class="hcsf_linklist">
+                            <li><a href="http://www.hearst.com/newspapers/san-francisco-chronicle.php">Our Company</a></li>
+                            <li><a class="ad-choice" href="http://www.aboutads.info/choices/"><span class="ad-link"></span> Ad Choices </a></li>
+                            <li><a href="http://www.sfchronicle.com/hr/">Careers</a></li>
+                            <li><a href="/terms_of_use/">Terms of Use</a></li>
+                            <li><a href="http://marketing.sfgate.com">Advertising</a></li>
+                            <li><a href="/privacy_policy">Privacy Policy</a></li>
+                            <li><a href="/privacy_policy#your_rights">Your Privacy Rights</a></li>
+                            <li><a href="/privacy_policy/#caprivacyrights">Your California Privacy Rights</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="hcsf_links">
+                    <li class="hcsf_contact">
+                        <h3>Contact</h3>
+                        <ul class="hcsf_linklist">
+                            <li><a href="/customer_service">Customer Service</a></li>
+                            <li><a href="/faq">Frequently Asked Questions</a></li>
+                            <li><a href="/newsroom_contacts">Newsroom Contacts</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="hcsf_links">
+                    <li class="hcsf_connect desktop">
+                        <h3>Connect</h3>
+                        <ul class="hcsf_linklist">
+                            <li><a class="fb-link" href="https://www.facebook.com/SFChronicle/">Facebook</a></li>
+                            <li><a class="twtr-link" href="https://twitter.com/sfchronicle">Twitter</a></li>
+                            <li><a class="li-link" href="https://www.linkedin.com/company/san-francisco-chronicle">LinkedIn</a></li>
+                            <li><a class="gplus-link" href="https://plus.google.com/+sfgate/posts">Google+</a></li>
+                        </ul>
+                    </li>
+                    <li class="hcsf_connect mobile">
+                        <h3>Connect</h3>
+                        <ul class="hcsf_linklist">
+                            <li><a class="fb-link" href="https://www.facebook.com/SFChronicle/"></a></li>
+                            <li><a class="twtr-link" href="https://twitter.com/sfchronicle"></a></li>
+                            <li><a class="li-link" href="https://www.linkedin.com/company/san-francisco-chronicle"></a></li>
+                            <li><a class="gplus-link" href="https://plus.google.com/+sfgate/posts"></a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="hcsf_links">
+                    <li class="hcsf_contact">
+                        <h3>Services</h3>
+                        <ul class="hcsf_linklist">
+                            <li><a href="/profile">Profile</a></li>
+                            <li><a href="/account">Subscriber Services</a></li>
+                            <li><a href="/e-edition">e-edition</a></li>
+                            <li><a href="/appdownload">App</a></li>
+                            <li><a href="/archive">Archives</a></li>
+                            <li><a href="/membership">Membership</a></li>
+                            <li><a href="/store">Store</a></li>
+                            <li><a href="/subscribe">Subscription Offers</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <div class="copyright-wrap">
+                    <img src="/img/modules/sitefooter/hst_copy_logo.png">
+                    <p class="copyright">© <script>document.write(new Date().getFullYear());</script> Hearst Corporation</p>
+                </div>
+            </div>
+
+
+
+        </div>
+    </div><!-- / hdnce-e -->  </body>
+</html>
+<!-- e src/business/templates/hearst/common/footer.tpl -->


### PR DESCRIPTION
CRAW-170:
http://www.morningstar.com/news/associated-press/urn:publicid:ap.org:f8d53c4370434744a864d4afa5fa8d36/hackers-break-into-centralized-password-manager-onelogin.html
- Wrong content were extracted
- Added css selector rule in setHighlyPositive

CRAW-163:
http://www.sfchronicle.com/business/article/Odd-jobs-matchmaker-Thumbtack-gets-big-funds-6541824.php
- Link http://thumbtack.com/ was missing in links section of extracted contents
- The paragraph containing the http://thumbtack.com/ was missing from extracted contents.
- Added a css selector rule in BEST_ELEMENT_PER_DOMAIN
- Link is now extracted
      {
        "offset": "5013",
        "text": "Thumbtack",
        "url": "http://thumbtack.com"
      },