### PR TITLE
Fixed JavaDoc issue

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -898,9 +898,9 @@ public class ArticleTextExtractor {
     /**
      * Removes `www.` and tld section from top level domain name
      *
-     * www.airpr.com -> airpr
-     * airpr.com -> airpr
-     * www.test.airpr.com -> Won't work, always expect a topLevelPrivateDomain
+     * www.airpr.com = airpr
+     * airpr.com = airpr
+     * www.test.airpr.com = Won't work, always expect a topLevelPrivateDomain
      *
      * @param domain {@link String}: Top Level domain name
      * @return: Domain name without tld and `www.`


### PR DESCRIPTION
/home/vagrant/snacktory/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java:903: error: bad use of '>'
[error]      * www.test.airpr.com -> Won't work, always expect a topLevelPrivateDomain
[error]