### PR TITLE
Remove scala as a dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,11 @@ val SnakeYaml = "org.yaml" % "snakeyaml" % "1.18"
 lazy val commonSettings = Seq(
   name := "snacktory-fork",
   version := "1.2.1-SNAPSHOT",
-  scalaVersion in ThisBuild := "2.11.8"
+  scalaVersion in ThisBuild := "2.11.8",
+  // Do not append Scala versions to the generated artifacts
+  crossPaths := false,
+  // This forbids including Scala related libraries into the dependency
+  autoScalaLibrary := false
 )
 
 lazy val snacktory = (project in file(".")).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.15


### PR DESCRIPTION
And do not append Scala versions to the generated artifacts.

Although this project is pure Java, it uses sbt which, by default, add a dependency on Scala. This dependency seems unused, so this commit make sure it is not there so there is no scala runtime coming through when we depend on this project.

I've also bumped sbt version to the latest available, just in case.